### PR TITLE
fix(ci): drop SSH detour in publish push-back; use GITHUB_TOKEN+HTTPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,15 @@ jobs:
         with:
           pypi-token: ${{ secrets.PYPI_PASSWORD }}
 
-      - name: Force SSH for git remote
-        run: git remote set-url origin git@github.com:${{ github.repository }}.git
-
+      # Push-back uses the GITHUB_TOKEN that `actions/checkout@v6` above already
+      # configured for HTTPS auth (the job has `permissions: contents: write`,
+      # which is exactly what's needed). The SSH detour previously here failed
+      # silently in any wads-managed repo lacking a deploy key, leaving PyPI
+      # one version ahead of `pyproject.toml`.
       - name: Commit Changes
         uses: i2mint/wads/actions/git-commit@master
         with:
           commit-message: "**CI** Formatted code + Updated version to ${{ env.VERSION }} [skip ci]"
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           push: true
 
       - name: Tag Repository

--- a/wads/data/github_ci_uv.yml
+++ b/wads/data/github_ci_uv.yml
@@ -217,14 +217,19 @@ jobs:
         with:
           pypi-token: ${{ secrets.PYPI_PASSWORD }}
 
-      - name: Force SSH for git remote
-        run: git remote set-url origin git@github.com:${{ github.repository }}.git
-
+      # Push-back uses the GITHUB_TOKEN that `actions/checkout@v6` above already
+      # configured for HTTPS auth (the job has `permissions: contents: write`,
+      # which is exactly what's needed). We previously switched the remote to
+      # SSH and used `secrets.SSH_PRIVATE_KEY` from a per-repo deploy key,
+      # which silently failed in every wads-managed repo that hadn't set that
+      # secret — leaving PyPI one version ahead of `pyproject.toml` and
+      # breaking the next merge's publish. The HTTPS+token path needs no
+      # per-repo setup and `GITHUB_TOKEN`-pushes do not retrigger workflows,
+      # which is also what we want here.
       - name: Commit Changes
         uses: i2mint/wads/actions/git-commit@master
         with:
           commit-message: "**CI** Formatted code + Updated version to ${{ env.VERSION }} [skip ci]"
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           push: true
 
       - name: Tag Repository


### PR DESCRIPTION
## Problem

Every wads-managed repo's `publish` job switches the git remote to SSH and pushes the version-bump commit + tag using `secrets.SSH_PRIVATE_KEY`:

```yaml
- name: Force SSH for git remote
  run: git remote set-url origin git@github.com:${{ github.repository }}.git

- name: Commit Changes
  uses: i2mint/wads/actions/git-commit@master
  with:
    ...
    ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
```

Without that secret (and a matching deploy key on the repo), the post-publish push-back of the bumped `pyproject.toml` + tag **silently fails**. PyPI ends up one patch version ahead of `master`. The next merge bumps from the stale version, tries to re-publish a duplicate on PyPI, and fails. Every other merge then breaks CI.

The workaround was a per-repo SSH deploy key setup (see the `wads-ci-fix` skill). That's ~2 minutes of manual config per repo across ~180 packages.

## Fix

`actions/checkout@v6` (already used by the publish job) configures HTTPS auth in `.git/config` using `secrets.GITHUB_TOKEN`, which is auto-provisioned and persisted by default (`persist-credentials: true`). The job already declares `permissions: contents: write` — exactly what `git push` needs.

So this PR:
- Removes the "Force SSH for git remote" step.
- Stops passing `ssh-private-key` to the `git-commit` action.

The push then goes over HTTPS using the auto-provisioned `GITHUB_TOKEN`. **No per-repo setup, no secret to manage, works on every wads-managed repo unmodified.**

A nice property of `GITHUB_TOKEN` pushes: [they do not retrigger workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). The `[skip ci]` in the commit message becomes belt-and-suspenders rather than essential.

## Compatibility

- Repos that **do** have `SSH_PRIVATE_KEY` set keep working — the secret just sits unused.
- The `git-commit` action's `ssh-private-key` input is still supported (its SSH-agent setup is conditional on the input being provided), so callers who want SSH for some reason can pass it explicitly.
- This change applies to the **uv** CI template (`github_ci_uv.yml`). The older `github_ci_publish_2025.yml` is not modified in this PR.

## Files changed

| File | Change |
|---|---|
| `wads/data/github_ci_uv.yml` | Drop SSH step + secret arg; comment block explains rationale. |
| `.github/workflows/ci.yml` (wads's own CI) | Same change so wads dogfoods the fix on next merge. |

## Verification done

Same fix landed in `i2mint/azuredol` and `i2mint/cosmodol` as direct commits (smaller blast radius). Their publish jobs ran green on the post-merge push and pushed the version-bump commit + tag back to master cleanly using only `GITHUB_TOKEN`. Confirms the approach works on a fresh repo with no SSH key set up.

## Follow-ups

- The `wads-ci-fix` skill's permanent-fix script (`setup-ssh-deploy-key.sh`) becomes obsolete for any repo using this template after merge — the skill's docstring can be updated to flag that. (Out of scope for this PR.)
- Existing wads-managed repos won't pick up this change automatically (they have a copy of the template). Either: (a) push the same one-line edit per repo, or (b) add a `wads-migrate` subcommand that re-syncs the publish block. Worth a separate issue.