### PR TITLE
CI: declare install extras via [tool.wads.ci.install].extras (closes #34)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,7 @@ The core design principle: **all project configuration lives in `pyproject.toml`
 | Section | Purpose |
 |---------|---------|
 | `[project]` | Standard Python project metadata |
+| `[tool.wads.ci.install]` | `extras` — package extras CI installs (`.[extras]`); empty = core deps only |
 | `[tool.wads.ci.testing]` | Python versions, pytest args, coverage, Windows testing |
 | `[tool.wads.ci.commands]` | Pre-test, test, post-test, lint, format commands |
 | `[tool.wads.ci.env]` | Environment variables (required, test, extra, defaults) |

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -88,6 +88,7 @@ jobs:
       tests-enabled: ${{ steps.config.outputs.tests-enabled }}
       build-sdist: ${{ steps.config.outputs.build-sdist }}
       build-wheel: ${{ steps.config.outputs.build-wheel }}
+      install-extras: ${{ steps.config.outputs.install-extras }}
       metrics-enabled: ${{ steps.config.outputs.metrics-enabled }}
       metrics-config-path: ${{ steps.config.outputs.metrics-config-path }}
       metrics-storage-branch: ${{ steps.config.outputs.metrics-storage-branch }}
@@ -146,6 +147,8 @@ jobs:
 
       - name: Install Dependencies
         uses: i2mint/wads/actions/install-deps-uv@master
+        with:
+          extras: ${{ needs.setup.outputs.install-extras }}
 
       - name: Format Source Code
         if: needs.setup.outputs.ruff-enabled != 'false'
@@ -216,6 +219,8 @@ jobs:
 
       - name: Install Dependencies
         uses: i2mint/wads/actions/install-deps-uv@master
+        with:
+          extras: ${{ needs.setup.outputs.install-extras }}
 
       - name: Run Tests
         uses: i2mint/wads/actions/run-tests-uv@master

--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ The tool will:
 
 Wads uses `pyproject.toml` as a single source of truth for CI configuration. Here's what you can configure:
 
+### Install Extras
+
+By default CI installs only your package's core dependencies. If your test suite
+needs an extra (e.g. a heavier `create`/`dev` group), declare it so CI installs
+`.[extras]`:
+
+```toml
+[tool.wads.ci.install]
+extras = "dev"          # or a list, e.g. ["dev", "test"]
+```
+
 ### Python Versions and Testing
 
 ```toml

--- a/actions/read-ci-config/action.yml
+++ b/actions/read-ci-config/action.yml
@@ -38,6 +38,9 @@ outputs:
   build-wheel:
     description: 'Whether to build wheel (true/false)'
     value: ${{ steps.config.outputs.build-wheel }}
+  install-extras:
+    description: 'Comma-separated extras for CI to install via pip''s .[extras] syntax (from [tool.wads.ci.install].extras). Empty installs only core deps.'
+    value: ${{ steps.config.outputs.install-extras }}
   metrics-enabled:
     description: 'Whether code metrics tracking is enabled (true/false)'
     value: ${{ steps.config.outputs.metrics-enabled }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,10 @@ select = ["D100"]
 minversion = "6.0"
 testpaths = ["wads/tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+
+[tool.wads.ci.install]
+# wads's own test suite exercises the full creation/publish flow (e.g. building
+# a generated package), so CI must install the heavier `create` extra in
+# addition to the light core. Consumed by the reusable workflow via
+# read-ci-config -> install-deps-uv (.[create]).
+extras = "create"

--- a/wads/ci_config.py
+++ b/wads/ci_config.py
@@ -71,6 +71,24 @@ class CIConfig:
         """Get the package installer to use in CI ('uv' or 'pip')."""
         return self.ci_config.get("installer", "uv")
 
+    @property
+    def install_extras(self) -> str:
+        """Extras to install in CI, as a comma-separated string for pip's
+        ``.[extras]`` syntax.
+
+        Read from ``[tool.wads.ci.install].extras`` (accepts a list or a
+        comma-separated string). Returns ``""`` when unset, in which case CI
+        installs only the package's core dependencies. Example: a project whose
+        tests need its heavier extra can set ``extras = "create"`` so the CI job
+        installs ``.[create]``.
+        """
+        extras = self.ci_config.get("install", {}).get("extras", "")
+        if isinstance(extras, str):
+            items = [e.strip() for e in extras.split(",") if e.strip()]
+        else:
+            items = [str(e).strip() for e in extras if str(e).strip()]
+        return ",".join(items)
+
     # ⚙️ EXECUTION FLOW AND COMMANDS
     @property
     def commands_pre_test(self) -> list[str]:

--- a/wads/scripts/read_ci_config.py
+++ b/wads/scripts/read_ci_config.py
@@ -89,6 +89,7 @@ def read_and_export_ci_config(pyproject_path: str | Path = ".") -> int:
 
         # Installer configuration
         _set_output("installer", config.installer)
+        _set_output("install-extras", config.install_extras)
 
         # Metrics configuration
         _set_output("metrics-enabled", config.metrics_enabled)

--- a/wads/tests/test_install_extras.py
+++ b/wads/tests/test_install_extras.py
@@ -1,0 +1,68 @@
+"""Tests for CI install-extras configuration ([tool.wads.ci.install].extras).
+
+Lets a repo declare which extras its CI should install (e.g. "create"), plumbed
+through CIConfig -> read_ci_config script -> read-ci-config action -> reusable
+workflow's install-deps step.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from wads.ci_config import CIConfig
+
+
+def _cfg(install_block):
+    return CIConfig({"tool": {"wads": {"ci": {"install": install_block}}}})
+
+
+def test_install_extras_default_empty():
+    assert CIConfig({}).install_extras == ""
+
+
+def test_install_extras_string():
+    assert _cfg({"extras": "create"}).install_extras == "create"
+
+
+def test_install_extras_comma_string_normalized():
+    assert _cfg({"extras": " create , test "}).install_extras == "create,test"
+
+
+def test_install_extras_list():
+    assert _cfg({"extras": ["create", "test"]}).install_extras == "create,test"
+
+
+def test_install_extras_empty_values_dropped():
+    assert _cfg({"extras": ["create", "", "  "]}).install_extras == "create"
+
+
+def test_wads_own_pyproject_installs_create():
+    """wads's own pyproject opts its CI into the create extra."""
+    repo_root = Path(__file__).resolve().parents[2]
+    cfg = CIConfig.from_file(repo_root / "pyproject.toml")
+    assert cfg.install_extras == "create"
+
+
+def test_read_ci_config_emits_install_extras(tmp_path, monkeypatch):
+    """The read_ci_config script writes install-extras to GITHUB_OUTPUT."""
+    from wads.scripts.read_ci_config import read_and_export_ci_config
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "demo"\nversion = "0.1.0"\n\n'
+        '[tool.wads.ci.install]\nextras = "create"\n'
+    )
+    out_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out_file))
+    # GITHUB_ENV is also written to; point it somewhere harmless.
+    monkeypatch.setenv("GITHUB_ENV", str(tmp_path / "gh_env"))
+
+    rc = read_and_export_ci_config(str(tmp_path))
+    assert rc == 0
+    output = out_file.read_text()
+    assert "install-extras=create" in output
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Follow-up to #32 (see #34).

Lets a repo declare which package extras its CI installs, so a test suite that needs a heavier extra runs instead of skipping. Plumbed through:

`CIConfig.install_extras` → `read_ci_config.py` (`install-extras` output) → `read-ci-config` action output → reusable `uv-ci.yml` setup output → `install-deps-uv` `extras` input (`.[extras]`).

- **wads's own pyproject** now sets `[tool.wads.ci.install] extras = "create"` so its build-path tests (`TestBuild`, currently importorskip-guarded) run in CI once this ships.
- **Backward compatible**: empty/absent extras installs core deps exactly as before. Both the validation and windows jobs pass the input.
- **Activation lag**: the `read-ci-config` action installs wads from PyPI, so the new `install-extras` output only appears after a wads release ships the updated `read_ci_config.py`. Until then it resolves to empty (safe no-op). This PR's own CI therefore still installs core-only and the build tests skip — expected.

Tests: `test_install_extras.py` covers the property (string/list/empty/whitespace), wads's own config resolving to `create`, and the script emitting `install-extras` to $GITHUB_OUTPUT. `242 passed` locally; ruff clean.

Closes #34. Refs #32.