### PR TITLE
feat(npm-ci): support pnpm in the reusable NPM workflow (additive)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -169,7 +169,16 @@ To migrate a legacy project:
   `wads.ci.publish.enabled` is true AND the commit message contains
   `[publish-npm]` (distinct from the Python publish trigger). OIDC trusted
   publishing + provenance by default; version-exists guard; no auto-bump.
-- `NpmCIConfig` (`wads/npm_config.py`) is the Python-side reader of that block.
+- **Package manager: npm (default) or pnpm.** The reusable workflow picks pnpm
+  when `wads.ci.packageManager == "pnpm"` OR a `pnpm-lock.yaml` is present in
+  the package dir (auto-detect in the `setup` job); else npm. The pnpm path adds
+  a conditional `pnpm/action-setup` (version read from the package's
+  `packageManager` field via `package_json_file`), switches the setup-node cache
+  + lockfile, and installs with `pnpm install --frozen-lockfile`. lint/test/build
+  and `npm publish` are unchanged. Additive: npm consumers (no field, no
+  `pnpm-lock.yaml`) see byte-identical behavior on `@master`.
+- `NpmCIConfig` (`wads/npm_config.py`) is the Python-side reader of that block
+  (`package_manager` property; `SUPPORTED_PACKAGE_MANAGERS`).
 
 ## CLI Reference
 

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -22,6 +22,12 @@
 #     token); NPM_TOKEN is a documented fallback for first-publish / private deps.
 #   - A pre-publish "version already on registry?" guard makes the job
 #     idempotent (no 403 on re-run); there is NO auto-bump on the JS side.
+#   - Package manager: npm by default. pnpm is supported and is selected either
+#     explicitly (wads.ci.packageManager = "pnpm") or auto-detected from a
+#     pnpm-lock.yaml in the package dir. pnpm consumers should declare a
+#     "packageManager": "pnpm@x.y.z" field in their package.json (pnpm's own
+#     convention) — the pnpm setup reads the version from there. npm consumers
+#     are unaffected (no pnpm-lock.yaml → npm).
 
 name: NPM CI
 
@@ -46,6 +52,7 @@ jobs:
     name: Read wads.ci config from package.json
     runs-on: ubuntu-latest
     outputs:
+      package_manager: ${{ steps.cfg.outputs.package_manager }}
       node_versions: ${{ steps.cfg.outputs.node_versions }}
       publish_node: ${{ steps.cfg.outputs.publish_node }}
       lint_command: ${{ steps.cfg.outputs.lint_command }}
@@ -64,10 +71,17 @@ jobs:
         run: |
           read_cfg() {
             node -e "
+              const fs = require('fs');
               const p = require('./package.json');
               const ci = (p.wads && p.wads.ci) || {};
               const pub = ci.publish || {};
+              // Explicit packageManager wins; else auto-detect pnpm via its
+              // lockfile; else npm. Existing npm repos (no field, no
+              // pnpm-lock.yaml) resolve to npm — unchanged behavior.
+              let pm = ci.packageManager || '';
+              if (!pm) pm = fs.existsSync('pnpm-lock.yaml') ? 'pnpm' : 'npm';
               const out = {
+                package_manager: pm,
                 node_versions: JSON.stringify(ci.nodeVersions || ['20','22','24']),
                 publish_node: String(ci.publishNode || '24'),
                 lint_command: ci.lintCommand || 'npm run lint --if-present',
@@ -94,14 +108,25 @@ jobs:
         node: ${{ fromJson(needs.setup.outputs.node_versions) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        if: needs.setup.outputs.package_manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          # Read the pnpm version from the package's own packageManager field.
+          package_json_file: ${{ inputs.package-dir }}/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
-          cache-dependency-path: ${{ inputs.package-dir }}/package-lock.json
+          cache: ${{ needs.setup.outputs.package_manager }}
+          cache-dependency-path: ${{ inputs.package-dir }}/${{ needs.setup.outputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json' }}
       - name: Install
         working-directory: ${{ inputs.package-dir }}
-        run: npm ci || npm install
+        run: |
+          if [ "${{ needs.setup.outputs.package_manager }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm ci || npm install
+          fi
       - name: Lint
         working-directory: ${{ inputs.package-dir }}
         run: ${{ needs.setup.outputs.lint_command }}
@@ -124,13 +149,23 @@ jobs:
       contains(github.event.head_commit.message, needs.setup.outputs.publish_marker)
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        if: needs.setup.outputs.package_manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ${{ inputs.package-dir }}/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup.outputs.publish_node }}
           registry-url: ${{ needs.setup.outputs.registry }}
       - name: Install
         working-directory: ${{ inputs.package-dir }}
-        run: npm ci || npm install
+        run: |
+          if [ "${{ needs.setup.outputs.package_manager }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm ci || npm install
+          fi
       - name: Build
         working-directory: ${{ inputs.package-dir }}
         run: ${{ needs.setup.outputs.build_command }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ long-lived token). Customize the subdirectory and package name with
 `--npm-subdir` / `--npm-package-name`; bring your own templates by pointing the
 generator at a different template source.
 
+**Package manager: npm or pnpm.** The reusable workflow drives **npm** by
+default and **pnpm** when selected — either explicitly via
+`wads.ci.packageManager` (or `populate --npm-package-manager pnpm`) or
+auto-detected from a `pnpm-lock.yaml` in the package directory. pnpm consumers
+should declare a `"packageManager": "pnpm@x.y.z"` field in their `package.json`
+(pnpm's own convention); the CI reads the pnpm version from there. Existing npm
+consumers are unaffected (no `pnpm-lock.yaml` → npm).
+
 ### Configure CI in pyproject.toml
 
 Edit your `pyproject.toml` to configure CI behavior:

--- a/wads/data/package_json_tpl.json
+++ b/wads/data/package_json_tpl.json
@@ -16,6 +16,7 @@
   "wads": {
     "ci": {
       "subdir": "<< npm_subdir >>",
+      "packageManager": "<< npm_package_manager >>",
       "nodeVersions": ["20", "22", "24"],
       "publishNode": "24",
       "lintCommand": "npm run lint --if-present",

--- a/wads/npm_config.py
+++ b/wads/npm_config.py
@@ -30,14 +30,23 @@ from pathlib import Path
 from typing import Union
 
 #: Defaults applied when a field is absent from ``wads.ci``.
+#:
+#: ``packageManager`` is ``"npm"`` here for the typed Python accessor, but in CI
+#: an *absent* field triggers auto-detection (a ``pnpm-lock.yaml`` in the
+#: package dir selects pnpm); an explicit value always wins. So existing npm
+#: consumers — no field, no ``pnpm-lock.yaml`` — keep byte-identical behavior.
 NPM_CI_DEFAULTS = {
     "subdir": "js",
+    "packageManager": "npm",
     "nodeVersions": ["20", "22", "24"],
     "publishNode": "24",
     "lintCommand": "npm run lint --if-present",
     "testCommand": "npm test --if-present",
     "buildCommand": "npm run build --if-present",
 }
+
+#: Package managers the reusable npm CI workflow knows how to drive.
+SUPPORTED_PACKAGE_MANAGERS = ("npm", "pnpm")
 
 #: Defaults for the nested ``wads.ci.publish`` block.
 NPM_PUBLISH_DEFAULTS = {
@@ -86,6 +95,17 @@ class NpmCIConfig:
     @property
     def subdir(self) -> str:
         return self._ci.get("subdir", NPM_CI_DEFAULTS["subdir"])
+
+    @property
+    def package_manager(self) -> str:
+        """The package manager driving install/build (``"npm"`` or ``"pnpm"``).
+
+        Returns the explicit ``wads.ci.packageManager`` if set, else the default
+        (``"npm"``). Note the CI workflow additionally *auto-detects* pnpm from a
+        ``pnpm-lock.yaml`` when the field is absent — this accessor reports only
+        the declared value.
+        """
+        return self._ci.get("packageManager", NPM_CI_DEFAULTS["packageManager"])
 
     @property
     def node_versions(self) -> list:

--- a/wads/populate.py
+++ b/wads/populate.py
@@ -292,6 +292,7 @@ def populate_pkg_dir(
     npm_subdir: str = "js",
     npm_package_name: str | None = None,
     npm_version: str = "0.0.1",
+    npm_package_manager: str = "npm",
     create_tests: bool = False,
     **configs,
 ):
@@ -340,6 +341,9 @@ def populate_pkg_dir(
     :param npm_subdir: Subdirectory holding the JS/TS package (default ``js``).
     :param npm_package_name: npm package name (defaults to the project name).
     :param npm_version: initial npm package version (default ``0.0.1``).
+    :param npm_package_manager: package manager for the JS/TS package —
+        ``"npm"`` (default) or ``"pnpm"``. pnpm consumers should also declare a
+        ``"packageManager": "pnpm@x.y.z"`` field in package.json.
     :param create_tests: If True, scaffold a ``tests/`` folder (``__init__.py``,
         a ``test_<name>.py`` smoke test, and a ``tests/util.py`` data accessor).
         Off by default so default output is unchanged.
@@ -871,6 +875,7 @@ def populate_pkg_dir(
             npm_subdir=npm_subdir,
             npm_package_name=npm_package_name,
             npm_version=npm_version,
+            npm_package_manager=npm_package_manager,
             overwrite=overwrite,
             on_add=tracker.add,
             on_skip=tracker.skip,

--- a/wads/profiles.py
+++ b/wads/profiles.py
@@ -50,6 +50,7 @@ def npm_overlay_context(
     npm_subdir: str = "js",
     npm_package_name: Optional[str] = None,
     npm_version: str = "0.0.1",
+    npm_package_manager: str = "npm",
 ) -> dict:
     """Build the render context for the NPM overlay artifacts."""
     return {
@@ -58,6 +59,7 @@ def npm_overlay_context(
         "description": description,
         "npm_license": _to_spdx(license),
         "npm_subdir": npm_subdir,
+        "npm_package_manager": npm_package_manager,
     }
 
 
@@ -94,6 +96,7 @@ def apply_npm_overlay(
     npm_subdir: str = "js",
     npm_package_name: Optional[str] = None,
     npm_version: str = "0.0.1",
+    npm_package_manager: str = "npm",
     overwrite=(),
     on_add=None,
     on_skip=None,
@@ -109,6 +112,7 @@ def apply_npm_overlay(
         npm_subdir=npm_subdir,
         npm_package_name=npm_package_name,
         npm_version=npm_version,
+        npm_package_manager=npm_package_manager,
     )
     return generate(
         pkg_dir,

--- a/wads/tests/test_npm_setup.py
+++ b/wads/tests/test_npm_setup.py
@@ -24,6 +24,7 @@ def test_npm_config_defaults_when_empty():
     cfg = NpmCIConfig({"name": "x"})
     assert cfg.has_ci_config() is False
     assert cfg.subdir == "js"
+    assert cfg.package_manager == "npm"
     assert cfg.node_versions == ["20", "22", "24"]
     assert cfg.publish_enabled is False
     assert cfg.publish_marker == "[publish-npm]"
@@ -37,6 +38,7 @@ def test_npm_config_reads_values():
         "wads": {
             "ci": {
                 "subdir": "frontend",
+                "packageManager": "pnpm",
                 "nodeVersions": ["22"],
                 "publish": {"enabled": True, "marker": "[ship-it]", "access": "restricted"},
             }
@@ -47,6 +49,7 @@ def test_npm_config_reads_values():
     assert cfg.package_name == "@scope/widget"
     assert cfg.version == "1.0.0"
     assert cfg.subdir == "frontend"
+    assert cfg.package_manager == "pnpm"
     assert cfg.node_versions == ["22"]
     assert cfg.publish_enabled is True
     assert cfg.publish_marker == "[ship-it]"
@@ -82,6 +85,7 @@ def test_apply_npm_overlay_writes_files(tmp_path):
     cfg = NpmCIConfig(pkg_json)
     assert cfg.has_ci_config()
     assert cfg.subdir == "js"
+    assert cfg.package_manager == "npm"  # default
     assert cfg.publish_enabled is False  # default OFF
 
     workflow = (tmp_path / ".github" / "workflows" / "npm-ci.yml").read_text()
@@ -104,6 +108,20 @@ def test_overlay_custom_subdir_and_name(tmp_path):
     workflow = (tmp_path / ".github" / "workflows" / "npm-ci.yml").read_text()
     assert "frontend/**" in workflow
     assert "package-dir: frontend" in workflow
+
+
+def test_overlay_pnpm_package_manager(tmp_path):
+    apply_npm_overlay(
+        str(tmp_path),
+        project_name="proj",
+        npm_subdir="ts",
+        npm_package_manager="pnpm",
+    )
+    pkg_json = json.loads((tmp_path / "ts" / "package.json").read_text())
+    assert NpmCIConfig(pkg_json).package_manager == "pnpm"
+    # No leftover Jinja marker for the new placeholder.
+    raw = (tmp_path / "ts" / "package.json").read_text()
+    assert "<<" not in raw and ">>" not in raw
 
 
 # --- populate --with-npm integration ------------------------------------------


### PR DESCRIPTION
## Summary

The reusable `npm-ci.yml` (added in #33) was **npm-only** — it runs `npm ci` and caches on `package-lock.json`, so a **pnpm** package (no `package-lock.json`) fails at the `setup-node` cache step. This adds **opt-in, backward-compatible pnpm support**.

- **setup** job resolves a `package_manager`: explicit `wads.ci.packageManager` wins; else auto-detect (`pnpm-lock.yaml` → `pnpm`, else `npm`).
- **validate** + **publish** jobs gain a conditional `pnpm/action-setup@v4` (pnpm version read from the package's own `packageManager` field via `package_json_file`), a package-manager-aware `setup-node` cache + lockfile path, and `pnpm install --frozen-lockfile`. The lint/test/build steps and `npm publish --provenance` are **unchanged** — `npm run build --if-present` works fine after a pnpm install.
- Python side: `NpmCIConfig.package_manager` + `SUPPORTED_PACKAGE_MANAGERS`; `packageManager` field in the `package.json` template; `npm_package_manager` param on `apply_npm_overlay` / `populate_pkg_dir`.
- Tests, README, and `.claude/CLAUDE.md` updated.

## Backward compatibility

**Additive.** Existing npm consumers (no `wads.ci.packageManager`, no `pnpm-lock.yaml`) resolve to `npm` with byte-identical behavior on `@master`. Only repos that opt in (a `pnpm-lock.yaml` or the explicit field) take the pnpm path.

## First customer

`kenburnz` (the pnpm TS package co-located in the `burns` repo) — validated end-to-end against this branch before merge (stub temporarily pinned to `@feat/npm-ci-pnpm`).

## Test plan

- [x] `pytest wads/tests/test_npm_setup.py` green (8 tests; adds packageManager default + pnpm overlay coverage)
- [x] workflow YAML + package.json template parse
- [ ] real CI run: kenburnz `npm-ci.yml` validate job green on the pnpm path (branch-pinned)