### PR TITLE
Generalize frontend setup into a language-profile registry (js + ts + ts-monorepo) (#39)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,12 +46,12 @@ wads/
 │   ├── git-commit/       # Auto-commit (SSH)
 │   └── git-tag/          # Create git tags
 ├── wads/                 # Main Python package
-│   ├── populate.py       # Project creation (`populate` CLI; `--with-npm` overlay)
+│   ├── populate.py       # Project creation (`populate` CLI; `--frontend` profiles)
 │   ├── pack.py           # Package publishing (`pack` CLI)
 │   ├── migration.py      # Migration tools (`wads-migrate` CLI)
 │   ├── templating.py     # ★ Declarative engine: TemplateSource (dict/fs/github)
 │   │                     #   + Jinja2 (<< >> delimiters) + Artifact/generate()
-│   ├── profiles.py       # Generation profiles/overlays (e.g. apply_npm_overlay)
+│   ├── profiles.py       # Frontend profile registry (js/ts/ts-monorepo) + apply_frontend
 │   ├── ci_config.py      # CIConfig class - reads pyproject.toml CI config
 │   ├── npm_config.py     # NpmCIConfig - reads package.json wads.ci block
 │   ├── install_system_deps.py  # System dependency installer
@@ -63,8 +63,11 @@ wads/
 │   │   │                                 #   5 lines, calls the reusable workflow
 │   │   ├── github_ci_uv.yml              # Inline uv workflow (escape valve / source
 │   │   │                                 #   of truth that the reusable workflow mirrors)
-│   │   ├── github_ci_npm_stub.yml        # NPM CI stub (populate --with-npm)
-│   │   ├── package_json_tpl.json         # package.json template w/ wads.ci block
+│   │   ├── github_ci_npm_stub.yml        # Frontend CI stub (populate --frontend)
+│   │   ├── package_json_tpl.json         # js package.json template w/ wads.ci block
+│   │   ├── package_json_ts_tpl.json      # ts package.json (tsup build, vitest)
+│   │   ├── tsconfig_tpl.json / ts_index_tpl.ts  # ts single-package scaffold
+│   │   ├── *_monorepo_*_tpl / pnpm_workspace_tpl.yaml / turbo_tpl.json  # ts-monorepo
 │   │   ├── github_ci_publish_2025.yml    # Legacy 2025 CI workflow template
 │   │   └── (other templates)
 │   ├── agents/           # AI diagnostic agents
@@ -151,34 +154,61 @@ To migrate a legacy project:
   semantics. `populate`'s static-file generation is driven by this engine.
 - **Profiles/overlays**: `wads/profiles.py`. The default `populate` produces the
   python-lib profile (output unchanged — pinned by characterization tests in
-  `wads/tests/test_populate_characterization.py`). `apply_npm_overlay` adds the
-  opt-in NPM setup.
+  `wads/tests/test_populate_characterization.py`). The **frontend profile
+  registry** (`FRONTEND_PROFILES` + `apply_frontend`) adds an opt-in JS/TS
+  component per selected profile; see the section below.
 - **Dependency extras**: light core (`jinja2`, `pyyaml`, `packaging`, `argh`,
   `tomli`/`-w`) for config-reading + templating; `wads[create]` adds the heavy
   creation/publish toolchain (`requests`, `build`, `wheel`, `ruamel.yaml`).
   `wads[all]` = create + docs. The light/`create` boundary is locked by
   `wads/tests/test_light_install.py`.
 
-### NPM CI (opt-in, `populate --with-npm`)
+### Frontend profiles (opt-in, `populate --frontend <profile>[,<profile>]`)
 
-- Mirrors the Python model on the JS/TS side: config lives in
-  `<subdir>/package.json` under a namespaced `"wads"` key (`wads.ci.*`); a stub
-  (`wads/data/github_ci_npm_stub.yml`) calls the **reusable workflow**
-  `i2mint/wads/.github/workflows/npm-ci.yml`.
-- **Validate always; publish opt-in**: publishes only when
-  `wads.ci.publish.enabled` is true AND the commit message contains
-  `[publish-npm]` (distinct from the Python publish trigger). OIDC trusted
-  publishing + provenance by default; version-exists guard; no auto-bump.
-- **Package manager: npm (default) or pnpm.** The reusable workflow picks pnpm
-  when `wads.ci.packageManager == "pnpm"` OR a `pnpm-lock.yaml` is present in
-  the package dir (auto-detect in the `setup` job); else npm. The pnpm path adds
-  a conditional `pnpm/action-setup` (version read from the package's
-  `packageManager` field via `package_json_file`), switches the setup-node cache
-  + lockfile, and installs with `pnpm install --frozen-lockfile`. lint/test/build
-  and `npm publish` are unchanged. Additive: npm consumers (no field, no
-  `pnpm-lock.yaml`) see byte-identical behavior on `@master`.
-- `NpmCIConfig` (`wads/npm_config.py`) is the Python-side reader of that block
-  (`package_manager` property; `SUPPORTED_PACKAGE_MANAGERS`).
+A small **registry of language/toolchain profiles** (issue #39) over the
+templating engine. Each profile = a `default_subdir`, a
+`default_package_manager`, and an `artifacts(context) -> [Artifact]` builder,
+registered in `FRONTEND_PROFILES` (extend via `register_frontend_profile`).
+`apply_frontend(profile=..., ...)` applies one component; `populate --frontend`
+applies a comma-separated list. `--with-npm` is a back-compat alias for
+`--frontend js`.
+
+Built-in profiles:
+
+- **`js`** — the original #32 overlay. Back-compat anchor: `js`-alone output is
+  **byte-identical** to pre-#39 (golden-pinned in
+  `wads/tests/data/golden/frontend_js/`). Subdir `js/`, single-package
+  `npm-ci.yml`.
+- **`ts`** — single-package TypeScript: `tsconfig.json` + `src/index.ts`, tsup
+  build + vitest, same `wads.ci` block + publish model. Subdir `ts/`.
+- **`ts-monorepo`** — pnpm workspaces + turbo: workspace-root `package.json`
+  (private), `pnpm-workspace.yaml`, `turbo.json`, `tsconfig.base.json`, and an
+  example `packages/core` package. Calls the **monorepo** reusable workflow.
+
+Shared model (mirrors the Python side): config lives in `<subdir>/package.json`
+under a namespaced `"wads"` key (`wads.ci.*`); a path-filtered stub
+(`wads/data/github_ci_npm_stub.yml`) calls a **reusable workflow**:
+
+- single-package → `i2mint/wads/.github/workflows/npm-ci.yml` (npm by default;
+  **pnpm** when `wads.ci.packageManager == "pnpm"` OR a `pnpm-lock.yaml` is
+  present — conditional `pnpm/action-setup`, version from the package's
+  `packageManager` field; lint/test/build + `npm publish` unchanged);
+- monorepo → `i2mint/wads/.github/workflows/npm-ci-monorepo.yml` (pnpm + turbo;
+  `setup` discovers workspace packages, `validate` runs turbo across them
+  matrixed over node, `publish` iterates packages with a per-package
+  version-exists guard).
+
+**Validate always; publish opt-in**: publishes only when
+`wads.ci.publish.enabled` is true AND the commit message contains `[publish-npm]`
+(distinct from the Python publish trigger). OIDC trusted publishing + provenance
+by default; version-exists guard; no auto-bump.
+
+**No collision**: the `js` component keeps the bare `npm-ci.yml`; every other
+component gets `npm-ci-<subdir>.yml`, each path-filtered to its own subdir, so a
+project can declare several components (e.g. `js` + `ts`) safely.
+
+`NpmCIConfig` (`wads/npm_config.py`) is the Python-side reader of the `wads.ci`
+block (`package_manager` property; `SUPPORTED_PACKAGE_MANAGERS`).
 
 ## CLI Reference
 
@@ -186,8 +216,10 @@ To migrate a legacy project:
 # Create a new project
 populate my-project --root-url https://github.com/user/my-project
 
-# Create a project that also has a JS/TS component with opt-in NPM publishing
-populate my-project --root-url https://github.com/user/my-project --with-npm
+# Create a project that also has frontend components with opt-in NPM publishing
+populate my-project --root-url https://github.com/user/my-project --frontend ts
+populate my-project --root-url https://github.com/user/my-project --frontend js,ts
+# (--with-npm is a back-compat alias for --frontend js)
 
 # Build and publish
 pack go .

--- a/.github/workflows/npm-ci-monorepo.yml
+++ b/.github/workflows/npm-ci-monorepo.yml
@@ -17,15 +17,15 @@
 #     wads.ci block.
 #   - `validate` installs the whole workspace once (pnpm) then runs turbo
 #     lint/test/build across every workspace package, matrixed over node. turbo
-#     provides the per-package fan-out + caching; the `setup` job additionally
-#     exposes a `packages` output (JSON array of package dirs) used by `publish`.
-#     (A future refinement may matrix `validate` over `node x package` for
-#     per-package status checks; turbo already parallelizes today.)
+#     provides the per-package fan-out + caching. (A future refinement may matrix
+#     `validate` over `node x package` for per-package status checks; turbo
+#     already parallelizes today.)
 #   - `publish` is OPT-IN: it runs only when wads.ci.publish.enabled is true AND
 #     the push is to the default branch AND the head commit message contains the
-#     publish marker (default "[publish-npm]"). It iterates the discovered
-#     packages, skipping any whose name@version is already on the registry
-#     (idempotent; no auto-bump), and publishes the rest with provenance.
+#     publish marker (default "[publish-npm]"). It uses `pnpm -r publish`, which
+#     publishes every public workspace package, rewrites `workspace:` protocol
+#     deps to real versions, and SKIPS any package whose version is already on
+#     the registry (idempotent; no auto-bump). Publishes with provenance.
 #   - pnpm only (monorepos are pnpm-workspace based); the pnpm version is read
 #     from the root package.json "packageManager" field by pnpm/action-setup.
 
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   setup:
-    name: Read wads.ci config + discover workspace packages
+    name: Read wads.ci config from root package.json
     runs-on: ubuntu-latest
     outputs:
       node_versions: ${{ steps.cfg.outputs.node_versions }}
@@ -62,12 +62,8 @@ jobs:
       registry: ${{ steps.cfg.outputs.registry }}
       provenance: ${{ steps.cfg.outputs.provenance }}
       access: ${{ steps.cfg.outputs.access }}
-      packages: ${{ steps.pkgs.outputs.packages }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ${{ inputs.package-dir }}/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
@@ -93,29 +89,6 @@ jobs:
             };
             for (const [k,v] of Object.entries(out)) console.log(k+'='+v);
           " >> "$GITHUB_OUTPUT"
-      - name: Install workspace
-        working-directory: ${{ inputs.package-dir }}
-        run: pnpm install --frozen-lockfile
-      - name: Discover workspace packages
-        id: pkgs
-        working-directory: ${{ inputs.package-dir }}
-        run: |
-          # Emit a JSON array of package dirs (relative to the workspace root)
-          # for every publishable (non-private) workspace package.
-          PKGS=$(pnpm -r list --depth -1 --json | node -e "
-            const fs = require('fs');
-            const data = JSON.parse(fs.readFileSync(0, 'utf8'));
-            const root = process.cwd();
-            const path = require('path');
-            const dirs = [];
-            for (const pkg of data) {
-              if (!pkg.path || pkg.path === root) continue;       // skip the root
-              const rel = path.relative(root, pkg.path);
-              dirs.push(rel);
-            }
-            console.log(JSON.stringify(dirs));
-          ")
-          echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
 
   validate:
     name: Validate (node ${{ matrix.node }})
@@ -173,29 +146,17 @@ jobs:
       - name: Build
         working-directory: ${{ inputs.package-dir }}
         run: ${{ needs.setup.outputs.build_command }}
-      - name: Publish changed packages
+      - name: Publish workspace packages
         working-directory: ${{ inputs.package-dir }}
         env:
           # Omitted/empty under OIDC trusted publishing; used only as a fallback.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PROVENANCE: ${{ needs.setup.outputs.provenance }}
           ACCESS: ${{ needs.setup.outputs.access }}
-          PACKAGES: ${{ needs.setup.outputs.packages }}
         run: |
+          # `pnpm -r publish` publishes every public workspace package, rewriting
+          # `workspace:` protocol deps to real versions and SKIPPING any package
+          # whose version is already on the registry (idempotent; no auto-bump).
           PROV=""
           if [ "$PROVENANCE" = "true" ]; then PROV="--provenance"; fi
-          echo "$PACKAGES" | node -e "
-            const fs = require('fs');
-            const dirs = JSON.parse(fs.readFileSync(0, 'utf8'));
-            for (const d of dirs) console.log(d);
-          " | while read -r dir; do
-            [ -z "$dir" ] && continue
-            NAME=$(node -p "require('./$dir/package.json').name")
-            VER=$(node -p "require('./$dir/package.json').version")
-            if npm view "$NAME@$VER" version >/dev/null 2>&1; then
-              echo "Skip: $NAME@$VER already published."
-            else
-              echo "Publish: $NAME@$VER"
-              ( cd "$dir" && npm publish $PROV --access "$ACCESS" )
-            fi
-          done
+          pnpm -r publish --access "$ACCESS" --no-git-checks $PROV

--- a/.github/workflows/npm-ci-monorepo.yml
+++ b/.github/workflows/npm-ci-monorepo.yml
@@ -1,0 +1,201 @@
+# Reusable NPM CI workflow for pnpm + turbo MONOREPOS (wads).
+#
+# Consumers call this from their own .github/workflows/npm-ci-<subdir>.yml stub:
+#
+#   jobs:
+#     npm-ci:
+#       uses: i2mint/wads/.github/workflows/npm-ci-monorepo.yml@master
+#       with:
+#         package-dir: ts          # the workspace root (contains pnpm-workspace.yaml)
+#       secrets:
+#         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}   # only needed as an OIDC fallback
+#
+# Design (mirrors the single-package npm-ci.yml SSOT model):
+#   - ALL configuration lives in the workspace ROOT package.json under the
+#     namespaced top-level "wads" key (wads.ci.*). The root is a private package
+#     that drives the workspace via turbo; individual workspace packages need no
+#     wads.ci block.
+#   - `validate` installs the whole workspace once (pnpm) then runs turbo
+#     lint/test/build across every workspace package, matrixed over node. turbo
+#     provides the per-package fan-out + caching; the `setup` job additionally
+#     exposes a `packages` output (JSON array of package dirs) used by `publish`.
+#     (A future refinement may matrix `validate` over `node x package` for
+#     per-package status checks; turbo already parallelizes today.)
+#   - `publish` is OPT-IN: it runs only when wads.ci.publish.enabled is true AND
+#     the push is to the default branch AND the head commit message contains the
+#     publish marker (default "[publish-npm]"). It iterates the discovered
+#     packages, skipping any whose name@version is already on the registry
+#     (idempotent; no auto-bump), and publishes the rest with provenance.
+#   - pnpm only (monorepos are pnpm-workspace based); the pnpm version is read
+#     from the root package.json "packageManager" field by pnpm/action-setup.
+
+name: NPM CI (monorepo)
+
+on:
+  workflow_call:
+    inputs:
+      package-dir:
+        description: "Workspace root (contains pnpm-workspace.yaml), relative to repo root."
+        type: string
+        default: "."
+    secrets:
+      NPM_TOKEN:
+        description: "npm auth token. Optional; only used as an OIDC fallback."
+        required: false
+
+permissions:
+  contents: read
+  id-token: write # for npm provenance / OIDC trusted publishing
+
+jobs:
+  setup:
+    name: Read wads.ci config + discover workspace packages
+    runs-on: ubuntu-latest
+    outputs:
+      node_versions: ${{ steps.cfg.outputs.node_versions }}
+      publish_node: ${{ steps.cfg.outputs.publish_node }}
+      lint_command: ${{ steps.cfg.outputs.lint_command }}
+      test_command: ${{ steps.cfg.outputs.test_command }}
+      build_command: ${{ steps.cfg.outputs.build_command }}
+      publish_enabled: ${{ steps.cfg.outputs.publish_enabled }}
+      publish_marker: ${{ steps.cfg.outputs.publish_marker }}
+      registry: ${{ steps.cfg.outputs.registry }}
+      provenance: ${{ steps.cfg.outputs.provenance }}
+      access: ${{ steps.cfg.outputs.access }}
+      packages: ${{ steps.pkgs.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ${{ inputs.package-dir }}/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Parse root package.json wads.ci
+        id: cfg
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          node -e "
+            const p = require('./package.json');
+            const ci = (p.wads && p.wads.ci) || {};
+            const pub = ci.publish || {};
+            const out = {
+              node_versions: JSON.stringify(ci.nodeVersions || ['20','22','24']),
+              publish_node: String(ci.publishNode || '24'),
+              lint_command: ci.lintCommand || 'pnpm turbo run lint',
+              test_command: ci.testCommand || 'pnpm turbo run test',
+              build_command: ci.buildCommand || 'pnpm turbo run build',
+              publish_enabled: String(pub.enabled === true),
+              publish_marker: pub.marker || '[publish-npm]',
+              registry: pub.registry || 'https://registry.npmjs.org',
+              provenance: String(pub.provenance !== false),
+              access: pub.access || 'public',
+            };
+            for (const [k,v] of Object.entries(out)) console.log(k+'='+v);
+          " >> "$GITHUB_OUTPUT"
+      - name: Install workspace
+        working-directory: ${{ inputs.package-dir }}
+        run: pnpm install --frozen-lockfile
+      - name: Discover workspace packages
+        id: pkgs
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          # Emit a JSON array of package dirs (relative to the workspace root)
+          # for every publishable (non-private) workspace package.
+          PKGS=$(pnpm -r list --depth -1 --json | node -e "
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync(0, 'utf8'));
+            const root = process.cwd();
+            const path = require('path');
+            const dirs = [];
+            for (const pkg of data) {
+              if (!pkg.path || pkg.path === root) continue;       // skip the root
+              const rel = path.relative(root, pkg.path);
+              dirs.push(rel);
+            }
+            console.log(JSON.stringify(dirs));
+          ")
+          echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: Validate (node ${{ matrix.node }})
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJson(needs.setup.outputs.node_versions) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ${{ inputs.package-dir }}/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+          cache-dependency-path: ${{ inputs.package-dir }}/pnpm-lock.yaml
+      - name: Install
+        working-directory: ${{ inputs.package-dir }}
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        working-directory: ${{ inputs.package-dir }}
+        run: ${{ needs.setup.outputs.lint_command }}
+      - name: Test
+        working-directory: ${{ inputs.package-dir }}
+        run: ${{ needs.setup.outputs.test_command }}
+      - name: Build
+        working-directory: ${{ inputs.package-dir }}
+        run: ${{ needs.setup.outputs.build_command }}
+
+  publish:
+    name: Publish workspace packages to npm
+    needs: [setup, validate]
+    runs-on: ubuntu-latest
+    # Opt-in: enabled in root package.json AND push to default branch AND marker present.
+    if: >-
+      needs.setup.outputs.publish_enabled == 'true' &&
+      github.event_name == 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      contains(github.event.head_commit.message, needs.setup.outputs.publish_marker)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ${{ inputs.package-dir }}/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.setup.outputs.publish_node }}
+          registry-url: ${{ needs.setup.outputs.registry }}
+      - name: Install
+        working-directory: ${{ inputs.package-dir }}
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        working-directory: ${{ inputs.package-dir }}
+        run: ${{ needs.setup.outputs.build_command }}
+      - name: Publish changed packages
+        working-directory: ${{ inputs.package-dir }}
+        env:
+          # Omitted/empty under OIDC trusted publishing; used only as a fallback.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PROVENANCE: ${{ needs.setup.outputs.provenance }}
+          ACCESS: ${{ needs.setup.outputs.access }}
+          PACKAGES: ${{ needs.setup.outputs.packages }}
+        run: |
+          PROV=""
+          if [ "$PROVENANCE" = "true" ]; then PROV="--provenance"; fi
+          echo "$PACKAGES" | node -e "
+            const fs = require('fs');
+            const dirs = JSON.parse(fs.readFileSync(0, 'utf8'));
+            for (const d of dirs) console.log(d);
+          " | while read -r dir; do
+            [ -z "$dir" ] && continue
+            NAME=$(node -p "require('./$dir/package.json').name")
+            VER=$(node -p "require('./$dir/package.json').version")
+            if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+              echo "Skip: $NAME@$VER already published."
+            else
+              echo "Publish: $NAME@$VER"
+              ( cd "$dir" && npm publish $PROV --access "$ACCESS" )
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -43,37 +43,56 @@ This creates a complete project structure with:
 - Package directory with `__init__.py`
 - GitHub Actions CI/CD workflow (optional)
 
-### Add NPM publishing for JS/TS components (optional)
+### Add a frontend component for JS/TS parts (optional)
 
-Python projects often ship a small JS/TS component (a widget, a browser UI).
-`populate --with-npm` adds a parametrized **NPM CI** alongside the Python one,
-following the same "config-file-driven, fixed-workflow" model:
+Python projects often ship a frontend component (a widget, a browser UI, a
+TypeScript library). `populate --frontend <profile>` adds a parametrized
+**NPM CI** alongside the Python one, following the same
+"config-file-driven, fixed-workflow" model. Pick one or more **profiles**:
+
+| Profile | Adds | Subdir | CI |
+|---|---|---|---|
+| `js` | `package.json` (npm) | `js/` | single-package `npm-ci.yml` |
+| `ts` | `package.json` + `tsconfig.json` + `src/index.ts` (tsup build, vitest) | `ts/` | single-package `npm-ci.yml` |
+| `ts-monorepo` | pnpm workspace root + `turbo.json` + an example `packages/core` | `ts/` | matrixed `npm-ci-monorepo.yml` |
 
 ```bash
-populate my-project --root-url https://github.com/user/my-project --with-npm
+# A single TypeScript component:
+populate my-project --root-url https://github.com/user/my-project --frontend ts
+
+# Several components at once — each in its own subdir, no workflow collision:
+populate my-project --root-url https://github.com/user/my-project --frontend js,ts
 ```
 
-This adds:
-- `js/package.json` — standard npm manifest with a namespaced `"wads"` config
-  block (`wads.ci.*`) controlling node versions, lint/test/build commands, and
-  publishing — analogous to `[tool.wads.ci]` in `pyproject.toml`.
-- `.github/workflows/npm-ci.yml` — a stub calling wads's reusable NPM workflow.
+`--with-npm` is kept as a back-compat alias for `--frontend js`.
+
+Each component gets:
+- a `package.json` with a namespaced `"wads"` config block (`wads.ci.*`)
+  controlling node versions, lint/test/build commands, and publishing —
+  analogous to `[tool.wads.ci]` in `pyproject.toml`;
+- a path-filtered `.github/workflows/npm-ci[-<subdir>].yml` stub calling wads's
+  reusable NPM workflow (the `js` component keeps the bare `npm-ci.yml`; every
+  other component gets `npm-ci-<subdir>.yml`, so multiple components never
+  collide).
 
 **Validation runs on every push/PR; publishing is opt-in.** It publishes only
 when `wads.ci.publish.enabled` is `true` **and** the commit message contains
 the marker **`[publish-npm]`** (deliberately distinct from the Python side).
 Publishing uses npm OIDC trusted publishing + provenance by default (no
-long-lived token). Customize the subdirectory and package name with
-`--npm-subdir` / `--npm-package-name`; bring your own templates by pointing the
-generator at a different template source.
+long-lived token). For a single component, customize the subdirectory and
+package name with `--npm-subdir` / `--npm-package-name`.
 
-**Package manager: npm or pnpm.** The reusable workflow drives **npm** by
-default and **pnpm** when selected — either explicitly via
+**Package manager: npm or pnpm.** The single-package reusable workflow drives
+**npm** by default and **pnpm** when selected — either explicitly via
 `wads.ci.packageManager` (or `populate --npm-package-manager pnpm`) or
 auto-detected from a `pnpm-lock.yaml` in the package directory. pnpm consumers
 should declare a `"packageManager": "pnpm@x.y.z"` field in their `package.json`
 (pnpm's own convention); the CI reads the pnpm version from there. Existing npm
-consumers are unaffected (no `pnpm-lock.yaml` → npm).
+consumers are unaffected (no `pnpm-lock.yaml` → npm). The `ts-monorepo` profile
+is pnpm-based by design.
+
+The profile set is extensible: register your own with
+`wads.profiles.register_frontend_profile(...)`.
 
 ### Configure CI in pyproject.toml
 

--- a/wads/__init__.py
+++ b/wads/__init__.py
@@ -36,9 +36,25 @@ github_ci_uv_path = rjoin(data_dir, "github_ci_uv.yml")
 # template is kept as an escape valve for repos that need to customize CI
 # beyond what `[tool.wads.ci.*]` exposes.
 github_ci_uv_stub_path = rjoin(data_dir, "github_ci_uv_stub.yml")
-# NPM overlay templates (opt-in `populate --with-npm`):
+# Frontend profile templates (opt-in `populate --frontend <profile>`, #39).
+# `js` (back-compat anchor):
 package_json_tpl_path = rjoin(data_dir, "package_json_tpl.json")
 github_ci_npm_stub_path = rjoin(data_dir, "github_ci_npm_stub.yml")
+# `ts` (single-package TypeScript):
+package_json_ts_tpl_path = rjoin(data_dir, "package_json_ts_tpl.json")
+tsconfig_tpl_path = rjoin(data_dir, "tsconfig_tpl.json")
+ts_index_tpl_path = rjoin(data_dir, "ts_index_tpl.ts")
+# `ts-monorepo` (pnpm workspaces + turbo):
+pnpm_workspace_tpl_path = rjoin(data_dir, "pnpm_workspace_tpl.yaml")
+turbo_tpl_path = rjoin(data_dir, "turbo_tpl.json")
+package_json_monorepo_root_tpl_path = rjoin(
+    data_dir, "package_json_monorepo_root_tpl.json"
+)
+tsconfig_base_tpl_path = rjoin(data_dir, "tsconfig_base_tpl.json")
+package_json_monorepo_pkg_tpl_path = rjoin(
+    data_dir, "package_json_monorepo_pkg_tpl.json"
+)
+tsconfig_monorepo_pkg_tpl_path = rjoin(data_dir, "tsconfig_monorepo_pkg_tpl.json")
 # Tests-folder templates (opt-in `populate --create-tests`, addresses #4):
 tests_init_tpl_path = rjoin(data_dir, "tests_init_tpl.py")
 test_smoke_tpl_path = rjoin(data_dir, "test_smoke_tpl.py")

--- a/wads/data/package_json_monorepo_pkg_tpl.json
+++ b/wads/data/package_json_monorepo_pkg_tpl.json
@@ -1,0 +1,30 @@
+{
+  "name": "<< example_package_name >>",
+  "version": "<< npm_version >>",
+  "description": "<< description >>",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "license": "<< npm_license >>",
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5",
+    "vitest": "^2"
+  }
+}

--- a/wads/data/package_json_monorepo_root_tpl.json
+++ b/wads/data/package_json_monorepo_root_tpl.json
@@ -1,0 +1,37 @@
+{
+  "name": "<< npm_package_name >>-monorepo",
+  "version": "<< npm_version >>",
+  "description": "<< description >>",
+  "private": true,
+  "packageManager": "pnpm@9.12.0",
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "lint": "turbo run lint"
+  },
+  "license": "<< npm_license >>",
+  "devDependencies": {
+    "turbo": "^2",
+    "typescript": "^5"
+  },
+  "wads": {
+    "ci": {
+      "subdir": "<< npm_subdir >>",
+      "packageManager": "pnpm",
+      "workspaceGlob": "<< npm_workspace_glob >>",
+      "nodeVersions": ["20", "22", "24"],
+      "publishNode": "24",
+      "lintCommand": "pnpm turbo run lint",
+      "testCommand": "pnpm turbo run test",
+      "buildCommand": "pnpm turbo run build",
+      "publish": {
+        "enabled": false,
+        "marker": "[publish-npm]",
+        "registry": "https://registry.npmjs.org",
+        "provenance": true,
+        "trustedPublishing": true,
+        "access": "public"
+      }
+    }
+  }
+}

--- a/wads/data/package_json_ts_tpl.json
+++ b/wads/data/package_json_ts_tpl.json
@@ -1,0 +1,49 @@
+{
+  "name": "<< npm_package_name >>",
+  "version": "<< npm_version >>",
+  "description": "<< description >>",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "license": "<< npm_license >>",
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5",
+    "vitest": "^2"
+  },
+  "wads": {
+    "ci": {
+      "subdir": "<< npm_subdir >>",
+      "packageManager": "<< npm_package_manager >>",
+      "nodeVersions": ["20", "22", "24"],
+      "publishNode": "24",
+      "lintCommand": "npm run lint --if-present",
+      "testCommand": "npm test --if-present",
+      "buildCommand": "npm run build --if-present",
+      "publish": {
+        "enabled": false,
+        "marker": "[publish-npm]",
+        "registry": "https://registry.npmjs.org",
+        "provenance": true,
+        "trustedPublishing": true,
+        "access": "public"
+      }
+    }
+  }
+}

--- a/wads/data/pnpm_workspace_tpl.yaml
+++ b/wads/data/pnpm_workspace_tpl.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "<< npm_workspace_glob >>"

--- a/wads/data/skills/setup-py-project/SKILL.md
+++ b/wads/data/skills/setup-py-project/SKILL.md
@@ -199,11 +199,22 @@ After the main setup, offer (don't force) these extras:
    cd /path/to/project && git add -A && git commit -m "Initial project setup via wads" && git push -u origin main
    ```
 
-4. **Publish to PyPI**: "Would you like to publish to PyPI? (This runs `pack go .`)"
+4. **Frontend component(s)**: If the project ships a JS/TS part (widget, browser UI, TS library), offer to add one or more **frontend profiles**. Each lands in its own subdir with a path-filtered NPM CI workflow (validate-always, publish-opt-in via `[publish-npm]`); multiple components never collide.
+   ```bash
+   # one TypeScript component (tsconfig + src + tsup/vitest):
+   populate my-project --root-url https://github.com/ORG/my-project --frontend ts
+   # several at once (each its own subdir):
+   populate my-project --root-url https://github.com/ORG/my-project --frontend js,ts
+   # a pnpm + turbo monorepo:
+   populate my-project --root-url https://github.com/ORG/my-project --frontend ts-monorepo
+   ```
+   Profiles: `js` (npm single-package), `ts` (TypeScript single-package), `ts-monorepo` (pnpm workspaces + turbo). `--with-npm` is a back-compat alias for `--frontend js`.
 
-5. **Enable GitHub Pages**: After the initial push (or after the first CI run that creates the `gh-pages` branch), enable Pages so the epythet-generated docs are served. **Do this automatically** — no need to ask, since the CI workflow already includes the `publish-github-pages` job.
+5. **Publish to PyPI**: "Would you like to publish to PyPI? (This runs `pack go .`)"
 
-6. **Enable GitHub Discussions**: **Do this automatically** unless the user explicitly asked not to enable discussions.
+6. **Enable GitHub Pages**: After the initial push (or after the first CI run that creates the `gh-pages` branch), enable Pages so the epythet-generated docs are served. **Do this automatically** — no need to ask, since the CI workflow already includes the `publish-github-pages` job.
+
+7. **Enable GitHub Discussions**: **Do this automatically** unless the user explicitly asked not to enable discussions.
 
    ```bash
    gh repo edit ORG/REPONAME --enable-discussions

--- a/wads/data/ts_index_tpl.ts
+++ b/wads/data/ts_index_tpl.ts
@@ -1,0 +1,4 @@
+/** Entry point. Replace with your package's public API. */
+export function hello(name = "world"): string {
+  return `Hello, ${name}!`;
+}

--- a/wads/data/tsconfig_base_tpl.json
+++ b/wads/data/tsconfig_base_tpl.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/wads/data/tsconfig_monorepo_pkg_tpl.json
+++ b/wads/data/tsconfig_monorepo_pkg_tpl.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/wads/data/tsconfig_tpl.json
+++ b/wads/data/tsconfig_tpl.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/wads/data/turbo_tpl.json
+++ b/wads/data/turbo_tpl.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    },
+    "lint": {}
+  }
+}

--- a/wads/populate.py
+++ b/wads/populate.py
@@ -288,6 +288,7 @@ def populate_pkg_dir(
     ci_def_path=None,
     ci_tpl_path=None,
     project_type=populate_dflts["project_type"],
+    frontend: str = "",
     with_npm: bool = False,
     npm_subdir: str = "js",
     npm_package_name: str | None = None,
@@ -334,10 +335,19 @@ def populate_pkg_dir(
     :param version_control_system: 'github' or 'gitlab' (will TRY to be resolved from root url if not given)
     :param ci_def_path: Path of the CI definition
     :param ci_tpl_path: Pater of the template definition
-    :param with_npm: If True, also add NPM setup for the project's JS/TS parts:
-        a ``<npm_subdir>/package.json`` (with a ``wads.ci`` config block) and a
-        ``.github/workflows/npm-ci.yml`` stub calling wads's reusable NPM
-        workflow. Validation runs on push/PR; publishing is opt-in. Off by default.
+    :param frontend: Comma-separated list of frontend profiles to add (issue
+        #39), e.g. ``"ts"`` or ``"js,ts"``. Available profiles: ``js`` (the
+        original npm overlay), ``ts`` (single-package TypeScript), and
+        ``ts-monorepo`` (pnpm workspaces + turbo). Each component lands in its
+        own subdir with its own path-filtered workflow, so multiple profiles
+        never collide. Empty by default. The single-component overrides below
+        (``npm_subdir`` / ``npm_package_name`` / ``npm_package_manager``) apply
+        only when exactly one profile is selected; with several, each profile
+        uses its own defaults.
+    :param with_npm: Back-compat alias for ``frontend="js"`` (issue #32). If
+        True, adds the ``js`` profile: a ``<npm_subdir>/package.json`` (with a
+        ``wads.ci`` config block) and a ``.github/workflows/npm-ci.yml`` stub
+        calling wads's reusable NPM workflow. Off by default.
     :param npm_subdir: Subdirectory holding the JS/TS package (default ``js``).
     :param npm_package_name: npm package name (defaults to the project name).
     :param npm_version: initial npm package version (default ``0.0.1``).
@@ -606,9 +616,7 @@ def populate_pkg_dir(
             if should_update(ci_def_path):
                 assert name in ci_def_path and name in _get_pkg_url_from_pkg_dir(
                     pkg_dir
-                ), (
-                    f"The name wasn't found in both the ci_def_path AND the git url, so I'm going to be safe and do nothing"
-                )
+                ), f"The name wasn't found in both the ci_def_path AND the git url, so I'm going to be safe and do nothing"
 
                 # Check if we should migrate old CI to new format
                 if migrate and version_control_system == "github":
@@ -862,24 +870,44 @@ def populate_pkg_dir(
             on_skip=tracker.skip,
         )
 
-    # NPM overlay (opt-in): add package.json + npm-ci workflow for JS/TS parts.
-    if with_npm:
-        from wads.profiles import apply_npm_overlay
+    # Frontend profiles (opt-in, issue #39): add a JS/TS component per selected
+    # profile. ``--with-npm`` is the back-compat alias for ``--frontend js``.
+    selected_frontends = [p.strip() for p in frontend.split(",") if p.strip()]
+    if with_npm and "js" not in selected_frontends:
+        selected_frontends = ["js"] + selected_frontends
+    # De-duplicate while preserving selection order.
+    _seen: set = set()
+    selected_frontends = [
+        p for p in selected_frontends if not (p in _seen or _seen.add(p))
+    ]
+    if selected_frontends:
+        from wads.profiles import apply_frontend
 
-        _clog("\n... adding NPM setup (package.json + npm-ci workflow)")
-        apply_npm_overlay(
-            pkg_dir,
-            project_name=name,
-            description=configs.get("description", ""),
-            license=configs.get("license"),
-            npm_subdir=npm_subdir,
-            npm_package_name=npm_package_name,
-            npm_version=npm_version,
-            npm_package_manager=npm_package_manager,
-            overwrite=overwrite,
-            on_add=tracker.add,
-            on_skip=tracker.skip,
+        # The single-component overrides (npm_subdir/name/package_manager) apply
+        # only when exactly one profile is selected; with several, each profile
+        # uses its own defaults so subdirs/workflows never collide.
+        single = len(selected_frontends) == 1
+        subdir_override = npm_subdir if (single and npm_subdir != "js") else None
+        pm_override = (
+            npm_package_manager if (single and npm_package_manager != "npm") else None
         )
+        name_override = npm_package_name if single else None
+        for profile_name in selected_frontends:
+            _clog(f"\n... adding frontend profile '{profile_name}'")
+            apply_frontend(
+                pkg_dir,
+                profile=profile_name,
+                project_name=name,
+                description=configs.get("description", ""),
+                license=configs.get("license"),
+                subdir=subdir_override,
+                package_name=name_override,
+                version=npm_version,
+                package_manager=pm_override,
+                overwrite=overwrite,
+                on_add=tracker.add,
+                on_skip=tracker.skip,
+            )
 
     # Print summary
     if verbose:
@@ -1136,9 +1164,9 @@ def update_pack_and_setup_py(
     target_pkg_dir = ensure_no_slash_suffix(target_pkg_dir)
     name = os.path.basename(target_pkg_dir)
     contents = os.listdir(target_pkg_dir)
-    assert {"setup.py", name}.issubset(contents), (
-        f"{target_pkg_dir} needs to have all three: {', '.join({'setup.py', name})}"
-    )
+    assert {"setup.py", name}.issubset(
+        contents
+    ), f"{target_pkg_dir} needs to have all three: {', '.join({'setup.py', name})}"
 
     pjoin = lambda *p: os.path.join(target_pkg_dir, *p)
 

--- a/wads/profiles.py
+++ b/wads/profiles.py
@@ -2,26 +2,53 @@
 
 A *profile* is a named declarative description of a project setup expressed as a
 list of :class:`wads.templating.Artifact`. The default profile (``python-lib``)
-is produced by :mod:`wads.populate`; this module currently provides the
-``npm`` **overlay** -- a set of artifacts *added to* an existing project to
-wire in NPM validation/publishing for its JS/TS components (issue #32).
+is produced by :mod:`wads.populate`.
 
-The overlay never runs by default: it is opt-in via ``populate --with-npm``.
+This module hosts two opt-in overlays added *on top of* an existing project:
+
+- The **frontend profile registry** (issue #39): a small registry of
+  language/toolchain profiles -- ``js`` (the original #32 overlay, the
+  back-compat anchor), ``ts`` (single-package TypeScript), and ``ts-monorepo``
+  (pnpm workspaces + turbo). A project may declare several frontend components
+  (e.g. ``js`` *and* ``ts``); each lives in its own subdir with its own
+  path-filtered workflow, so they never collide. Selected via
+  ``populate --frontend <profile>[,<profile>]`` (``--with-npm`` stays as an
+  alias for ``--frontend js``). Profiles are extensible through
+  :func:`register_frontend_profile`.
+- The **tests-folder overlay** (issue #4): scaffolds a ``tests/`` package.
+
+Nothing here runs by default; the Python ``populate`` path and the
+``name/name/`` root layout are untouched.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Optional
+from dataclasses import dataclass
+from typing import Callable, Mapping, Optional
 
 from wads import (
     package_json_tpl_path,
     github_ci_npm_stub_path,
+    package_json_ts_tpl_path,
+    tsconfig_tpl_path,
+    ts_index_tpl_path,
+    pnpm_workspace_tpl_path,
+    turbo_tpl_path,
+    package_json_monorepo_root_tpl_path,
+    tsconfig_base_tpl_path,
+    package_json_monorepo_pkg_tpl_path,
+    tsconfig_monorepo_pkg_tpl_path,
     tests_init_tpl_path,
     test_smoke_tpl_path,
     tests_util_tpl_path,
 )
-from wads.templating import Artifact, FilesystemTemplateSource, generate
+from wads.templating import (
+    Artifact,
+    FilesystemTemplateSource,
+    GenerationResult,
+    generate,
+)
 
 # Map common license identifiers to SPDX identifiers npm expects.
 _SPDX_BY_NAME = {
@@ -42,6 +69,283 @@ def _to_spdx(license_name: Optional[str]) -> str:
     return _SPDX_BY_NAME.get(license_name.strip().lower(), license_name)
 
 
+# --------------------------------------------------------------------------------------
+# Frontend profile registry (issue #39)
+#
+# Each profile is a declarative description of one frontend component: where it
+# lives (``default_subdir``), which package manager drives it
+# (``default_package_manager``), and an ``artifacts(context) -> list[Artifact]``
+# builder. Profiles are registered in :data:`FRONTEND_PROFILES` and selected by
+# name. A single :func:`apply_frontend` call applies one component; a project may
+# apply several (e.g. ``js`` and ``ts``) without collision because each component
+# owns its own subdir and a per-subdir workflow file.
+# --------------------------------------------------------------------------------------
+
+# The reusable workflow each profile's stub calls (hosted in this repo).
+_SINGLE_PACKAGE_REUSABLE = "npm-ci.yml"
+_MONOREPO_REUSABLE = "npm-ci-monorepo.yml"
+
+
+def _workflow_basename(subdir: str) -> str:
+    """Per-component workflow filename, collision-free across subdirs.
+
+    Back-compat anchor: the historical single overlay (subdir ``js``) keeps the
+    bare ``npm-ci.yml`` name, so existing ``js`` output stays byte-compatible;
+    every other component gets ``npm-ci-<subdir>.yml`` (slashes flattened),
+    path-filtered to its own subdir.
+
+    >>> _workflow_basename("js")
+    'npm-ci.yml'
+    >>> _workflow_basename("ts")
+    'npm-ci-ts.yml'
+    """
+    if subdir == "js":
+        return "npm-ci.yml"
+    slug = subdir.strip("/").replace("/", "-")
+    return f"npm-ci-{slug}.yml"
+
+
+def _workflow_name(subdir: str) -> str:
+    """Human-facing workflow ``name:`` -- ``NPM CI`` for the ``js`` anchor."""
+    return "NPM CI" if subdir == "js" else f"NPM CI ({subdir})"
+
+
+def frontend_context(
+    *,
+    profile_name: str,
+    project_name: str,
+    description: str = "",
+    license: Optional[str] = None,
+    subdir: str,
+    package_name: Optional[str] = None,
+    version: str = "0.0.1",
+    package_manager: str = "npm",
+    workspace_glob: str = "packages/*",
+    example_package_name: Optional[str] = None,
+) -> dict:
+    """Build the render context shared by all frontend-profile templates.
+
+    The returned mapping is a superset: it carries the keys every profile's
+    templates may reference (single-package and monorepo). Unused keys are
+    harmless under Jinja ``StrictUndefined`` because that only errors on keys a
+    template *references* yet are missing.
+    """
+    reusable = (
+        _MONOREPO_REUSABLE
+        if profile_name == "ts-monorepo"
+        else _SINGLE_PACKAGE_REUSABLE
+    )
+    return {
+        "npm_package_name": package_name or project_name,
+        "npm_version": version,
+        "description": description,
+        "npm_license": _to_spdx(license),
+        "npm_subdir": subdir,
+        "npm_package_manager": package_manager,
+        # Stub workflow wiring (per-component, collision-free):
+        "npm_workflow_name": _workflow_name(subdir),
+        "npm_workflow_file": _workflow_basename(subdir),
+        "reusable_workflow": reusable,
+        # Monorepo-only context (ignored by single-package templates):
+        "npm_workspace_glob": workspace_glob,
+        "example_package_name": example_package_name or (package_name or project_name),
+    }
+
+
+def _src(tpl_path: str) -> FilesystemTemplateSource:
+    """One-entry filesystem source whose key is the template's basename."""
+    return FilesystemTemplateSource(os.path.dirname(tpl_path))
+
+
+def _jinja(target: str, tpl_path: str) -> Artifact:
+    return Artifact.from_jinja(target, os.path.basename(tpl_path), _src(tpl_path))
+
+
+def _copy(target: str, tpl_path: str) -> Artifact:
+    return Artifact.from_copy(target, os.path.basename(tpl_path), _src(tpl_path))
+
+
+def _stub_artifact(subdir: str) -> Artifact:
+    """The ``.github/workflows/<file>.yml`` stub for a component in ``subdir``.
+
+    The target filename is resolved in Python (collision-free per subdir); the
+    stub *content* renders the same filename into its own path filter via the
+    ``npm_workflow_file`` context key.
+    """
+    return _jinja(
+        f".github/workflows/{_workflow_basename(subdir)}", github_ci_npm_stub_path
+    )
+
+
+# --- per-profile artifact builders --------------------------------------------
+
+
+def _js_artifacts(ctx: Mapping) -> list:
+    """``js`` profile: the original #32 overlay (back-compat anchor)."""
+    subdir = ctx["npm_subdir"]
+    return [
+        _jinja(f"{subdir}/package.json", package_json_tpl_path),
+        _stub_artifact(subdir),
+    ]
+
+
+def _ts_artifacts(ctx: Mapping) -> list:
+    """``ts`` profile: single-package TypeScript (tsconfig + src + build/test)."""
+    subdir = ctx["npm_subdir"]
+    return [
+        _jinja(f"{subdir}/package.json", package_json_ts_tpl_path),
+        _copy(f"{subdir}/tsconfig.json", tsconfig_tpl_path),
+        _copy(f"{subdir}/src/index.ts", ts_index_tpl_path),
+        _stub_artifact(subdir),
+    ]
+
+
+def _ts_monorepo_artifacts(ctx: Mapping) -> list:
+    """``ts-monorepo`` profile: pnpm workspaces + turbo, one example package.
+
+    The workspace root lives at ``<subdir>/`` and an example package at
+    ``<subdir>/packages/core/``. The stub calls the reusable *monorepo* workflow,
+    which discovers and matrixes over the workspace packages.
+    """
+    subdir = ctx["npm_subdir"]
+    pkg_dir = f"{subdir}/packages/core"
+    return [
+        _jinja(f"{subdir}/package.json", package_json_monorepo_root_tpl_path),
+        _jinja(f"{subdir}/pnpm-workspace.yaml", pnpm_workspace_tpl_path),
+        _copy(f"{subdir}/turbo.json", turbo_tpl_path),
+        _copy(f"{subdir}/tsconfig.base.json", tsconfig_base_tpl_path),
+        _jinja(f"{pkg_dir}/package.json", package_json_monorepo_pkg_tpl_path),
+        _copy(f"{pkg_dir}/tsconfig.json", tsconfig_monorepo_pkg_tpl_path),
+        _copy(f"{pkg_dir}/src/index.ts", ts_index_tpl_path),
+        _stub_artifact(subdir),
+    ]
+
+
+@dataclass(frozen=True)
+class FrontendProfile:
+    """A declarative frontend language/toolchain profile.
+
+    :param name: registry key (e.g. ``"js"``, ``"ts"``, ``"ts-monorepo"``).
+    :param default_subdir: subdir the component lives in when unspecified.
+    :param default_package_manager: ``"npm"`` or ``"pnpm"``.
+    :param artifacts: ``context -> list[Artifact]`` builder for this profile.
+    :param description: one-line human summary.
+    """
+
+    name: str
+    default_subdir: str
+    default_package_manager: str
+    artifacts: Callable[[Mapping], list]
+    description: str = ""
+
+
+#: The frontend profile registry. Extend it via :func:`register_frontend_profile`.
+FRONTEND_PROFILES: dict = {}
+
+
+def register_frontend_profile(profile: FrontendProfile) -> FrontendProfile:
+    """Register (or override) a frontend profile by name. Returns the profile."""
+    FRONTEND_PROFILES[profile.name] = profile
+    return profile
+
+
+def get_frontend_profile(name: str) -> FrontendProfile:
+    """Look up a registered profile, with an informative error if unknown."""
+    try:
+        return FRONTEND_PROFILES[name]
+    except KeyError:
+        available = ", ".join(sorted(FRONTEND_PROFILES)) or "(none registered)"
+        raise ValueError(
+            f"Unknown frontend profile {name!r}. Available: {available}."
+        ) from None
+
+
+register_frontend_profile(
+    FrontendProfile(
+        name="js",
+        default_subdir="js",
+        default_package_manager="npm",
+        artifacts=_js_artifacts,
+        description="JavaScript single package (the original #32 overlay).",
+    )
+)
+register_frontend_profile(
+    FrontendProfile(
+        name="ts",
+        default_subdir="ts",
+        default_package_manager="npm",
+        artifacts=_ts_artifacts,
+        description="TypeScript single package (tsconfig + tsup build + vitest).",
+    )
+)
+register_frontend_profile(
+    FrontendProfile(
+        name="ts-monorepo",
+        default_subdir="ts",
+        default_package_manager="pnpm",
+        artifacts=_ts_monorepo_artifacts,
+        description="TypeScript monorepo (pnpm workspaces + turbo).",
+    )
+)
+
+
+def apply_frontend(
+    pkg_dir: str,
+    *,
+    profile: str = "js",
+    project_name: str,
+    description: str = "",
+    license: Optional[str] = None,
+    subdir: Optional[str] = None,
+    package_name: Optional[str] = None,
+    version: str = "0.0.1",
+    package_manager: Optional[str] = None,
+    workspace_glob: str = "packages/*",
+    example_package_name: Optional[str] = None,
+    overwrite=(),
+    on_add=None,
+    on_skip=None,
+) -> GenerationResult:
+    """Apply one frontend profile component to an existing project directory.
+
+    ``subdir`` and ``package_manager`` default to the selected profile's
+    defaults. Returns the :class:`wads.templating.GenerationResult`.
+
+    >>> import tempfile
+    >>> d = tempfile.mkdtemp()
+    >>> res = apply_frontend(d, profile="ts", project_name="widget")
+    >>> sorted(res.added)  # doctest: +NORMALIZE_WHITESPACE
+    ['.github/workflows/npm-ci-ts.yml', 'ts/package.json', 'ts/src/index.ts',
+     'ts/tsconfig.json']
+    """
+    prof = get_frontend_profile(profile)
+    subdir = subdir or prof.default_subdir
+    package_manager = package_manager or prof.default_package_manager
+    context = frontend_context(
+        profile_name=prof.name,
+        project_name=project_name,
+        description=description,
+        license=license,
+        subdir=subdir,
+        package_name=package_name,
+        version=version,
+        package_manager=package_manager,
+        workspace_glob=workspace_glob,
+        example_package_name=example_package_name,
+    )
+    return generate(
+        pkg_dir,
+        prof.artifacts(context),
+        context,
+        overwrite=overwrite,
+        on_add=on_add,
+        on_skip=on_skip,
+    )
+
+
+# --- back-compat shims (the pre-#39 npm-overlay surface) -----------------------
+
+
 def npm_overlay_context(
     *,
     project_name: str,
@@ -52,39 +356,22 @@ def npm_overlay_context(
     npm_version: str = "0.0.1",
     npm_package_manager: str = "npm",
 ) -> dict:
-    """Build the render context for the NPM overlay artifacts."""
-    return {
-        "npm_package_name": npm_package_name or project_name,
-        "npm_version": npm_version,
-        "description": description,
-        "npm_license": _to_spdx(license),
-        "npm_subdir": npm_subdir,
-        "npm_package_manager": npm_package_manager,
-    }
+    """Deprecated: render context for the ``js`` overlay. Use :func:`apply_frontend`."""
+    return frontend_context(
+        profile_name="js",
+        project_name=project_name,
+        description=description,
+        license=license,
+        subdir=npm_subdir,
+        package_name=npm_package_name,
+        version=npm_version,
+        package_manager=npm_package_manager,
+    )
 
 
 def npm_overlay_artifacts(npm_subdir: str = "js") -> list:
-    """Artifacts that add NPM setup + CI to a project.
-
-    Writes ``<npm_subdir>/package.json`` (with the ``wads.ci`` config block) and
-    ``.github/workflows/npm-ci.yml`` (the stub calling the reusable workflow).
-    """
-    # Each template file is its own one-entry filesystem source so the engine's
-    # source key is just the file's basename.
-    pkg_json_src = FilesystemTemplateSource(os.path.dirname(package_json_tpl_path))
-    stub_src = FilesystemTemplateSource(os.path.dirname(github_ci_npm_stub_path))
-    return [
-        Artifact.from_jinja(
-            f"{npm_subdir}/package.json",
-            os.path.basename(package_json_tpl_path),
-            pkg_json_src,
-        ),
-        Artifact.from_jinja(
-            ".github/workflows/npm-ci.yml",
-            os.path.basename(github_ci_npm_stub_path),
-            stub_src,
-        ),
-    ]
+    """Deprecated: the ``js`` overlay artifacts. Use the ``js`` frontend profile."""
+    return _js_artifacts({"npm_subdir": npm_subdir})
 
 
 def apply_npm_overlay(
@@ -101,23 +388,21 @@ def apply_npm_overlay(
     on_add=None,
     on_skip=None,
 ):
-    """Add NPM setup + CI to an existing project directory.
+    """Deprecated alias for ``apply_frontend(profile="js", ...)`` (issue #32 surface).
 
-    Returns the :class:`wads.templating.GenerationResult`.
+    Kept so existing callers and tests keep working; new code should call
+    :func:`apply_frontend`.
     """
-    context = npm_overlay_context(
+    return apply_frontend(
+        pkg_dir,
+        profile="js",
         project_name=project_name,
         description=description,
         license=license,
-        npm_subdir=npm_subdir,
-        npm_package_name=npm_package_name,
-        npm_version=npm_version,
-        npm_package_manager=npm_package_manager,
-    )
-    return generate(
-        pkg_dir,
-        npm_overlay_artifacts(npm_subdir),
-        context,
+        subdir=npm_subdir,
+        package_name=npm_package_name,
+        version=npm_version,
+        package_manager=npm_package_manager,
         overwrite=overwrite,
         on_add=on_add,
         on_skip=on_skip,

--- a/wads/tests/data/golden/frontend_js/.github/workflows/npm-ci.yml
+++ b/wads/tests/data/golden/frontend_js/.github/workflows/npm-ci.yml
@@ -1,6 +1,6 @@
 # wads NPM CI — calls the reusable workflow hosted in i2mint/wads.
 #
-# All configuration lives in << npm_subdir >>/package.json under the "wads"
+# All configuration lives in js/package.json under the "wads"
 # key (wads.ci.*). This workflow only runs when the JS subdirectory changes,
 # so it never collides with the Python ci.yml.
 #
@@ -9,22 +9,22 @@
 # Publishing uses OIDC trusted publishing by default (configure the trusted
 # publisher for this repo + workflow filename on npmjs.com). NPM_TOKEN is only
 # needed as a fallback (e.g. the very first publish of a new package name).
-name: << npm_workflow_name >>
+name: NPM CI
 on:
   push:
     paths:
-      - "<< npm_subdir >>/**"
-      - ".github/workflows/<< npm_workflow_file >>"
+      - "js/**"
+      - ".github/workflows/npm-ci.yml"
   pull_request:
     paths:
-      - "<< npm_subdir >>/**"
+      - "js/**"
 jobs:
   npm-ci:
-    uses: i2mint/wads/.github/workflows/<< reusable_workflow >>@master
+    uses: i2mint/wads/.github/workflows/npm-ci.yml@master
     permissions:
       contents: read
       id-token: write # npm provenance / OIDC trusted publishing
     with:
-      package-dir: << npm_subdir >>
+      package-dir: js
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/wads/tests/data/golden/frontend_js/js/package.json
+++ b/wads/tests/data/golden/frontend_js/js/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "mypkg",
+  "version": "0.0.1",
+  "description": "A widget",
+  "type": "module",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "lint": "echo \"(no lint configured)\" && exit 0",
+    "test": "echo \"(no tests configured)\" && exit 0",
+    "build": "echo \"(no build configured)\" && exit 0"
+  },
+  "license": "Apache-2.0",
+  "wads": {
+    "ci": {
+      "subdir": "js",
+      "packageManager": "npm",
+      "nodeVersions": ["20", "22", "24"],
+      "publishNode": "24",
+      "lintCommand": "npm run lint --if-present",
+      "testCommand": "npm test --if-present",
+      "buildCommand": "npm run build --if-present",
+      "publish": {
+        "enabled": false,
+        "marker": "[publish-npm]",
+        "registry": "https://registry.npmjs.org",
+        "provenance": true,
+        "trustedPublishing": true,
+        "access": "public"
+      }
+    }
+  }
+}

--- a/wads/tests/test_frontend_profiles.py
+++ b/wads/tests/test_frontend_profiles.py
@@ -1,0 +1,258 @@
+"""Tests for the frontend profile registry (issue #39).
+
+Covers:
+- the ``js`` profile stays byte-compatible with the pre-#39 overlay (golden
+  files under ``wads/tests/data/golden/frontend_js/``);
+- the ``ts`` single-package profile;
+- the ``ts-monorepo`` profile (pnpm workspaces + turbo);
+- multiple components (``js`` + ``ts``) coexisting without workflow collision;
+- the registry surface and the ``populate --frontend`` CLI integration.
+
+The ``js`` golden anchors the back-compat acceptance; if you *intentionally*
+change ``js`` output, regenerate the goldens and review the diff in the PR.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from wads.npm_config import NpmCIConfig
+from wads.profiles import (
+    FRONTEND_PROFILES,
+    FrontendProfile,
+    apply_frontend,
+    get_frontend_profile,
+    register_frontend_profile,
+    _workflow_basename,
+)
+from wads.populate import populate_pkg_dir
+
+GOLDEN_DIR = Path(__file__).parent / "data" / "golden" / "frontend_js"
+
+
+def _git_init(pkg_dir, url):
+    subprocess.run(["git", "init", "-q"], cwd=pkg_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=pkg_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=pkg_dir, check=True)
+    subprocess.run(["git", "remote", "add", "origin", url], cwd=pkg_dir, check=True)
+
+
+# --- registry ------------------------------------------------------------------
+
+
+def test_registry_has_builtin_profiles():
+    assert set(FRONTEND_PROFILES) >= {"js", "ts", "ts-monorepo"}
+    assert get_frontend_profile("js").default_subdir == "js"
+    assert get_frontend_profile("ts").default_subdir == "ts"
+    assert get_frontend_profile("ts-monorepo").default_package_manager == "pnpm"
+
+
+def test_unknown_profile_is_informative():
+    with pytest.raises(ValueError, match="Unknown frontend profile 'nope'"):
+        get_frontend_profile("nope")
+
+
+def test_workflow_basename_scheme():
+    # js is the back-compat anchor; everything else is per-subdir.
+    assert _workflow_basename("js") == "npm-ci.yml"
+    assert _workflow_basename("ts") == "npm-ci-ts.yml"
+    assert _workflow_basename("frontend") == "npm-ci-frontend.yml"
+
+
+def test_register_custom_profile_roundtrip():
+    sentinel = FrontendProfile(
+        name="_test_custom",
+        default_subdir="x",
+        default_package_manager="npm",
+        artifacts=lambda ctx: [],
+    )
+    try:
+        register_frontend_profile(sentinel)
+        assert get_frontend_profile("_test_custom") is sentinel
+    finally:
+        FRONTEND_PROFILES.pop("_test_custom", None)
+
+
+# --- js profile: byte-compatible back-compat anchor ----------------------------
+
+
+def test_js_profile_matches_golden(tmp_path):
+    apply_frontend(
+        str(tmp_path),
+        profile="js",
+        project_name="mypkg",
+        description="A widget",
+        license="apache-2.0",
+    )
+    for golden in GOLDEN_DIR.rglob("*"):
+        if not golden.is_file():
+            continue
+        rel = golden.relative_to(GOLDEN_DIR)
+        produced = (tmp_path / rel).read_text()
+        assert produced == golden.read_text(), f"js output drifted for {rel}"
+
+
+def test_js_via_apply_frontend_default_profile(tmp_path):
+    # profile defaults to "js"
+    result = apply_frontend(str(tmp_path), project_name="mypkg")
+    assert "js/package.json" in result.added
+    assert ".github/workflows/npm-ci.yml" in result.added
+
+
+# --- ts single-package profile -------------------------------------------------
+
+
+def test_ts_profile_writes_expected_files(tmp_path):
+    result = apply_frontend(str(tmp_path), profile="ts", project_name="widget")
+    assert set(result.added) == {
+        "ts/package.json",
+        "ts/tsconfig.json",
+        "ts/src/index.ts",
+        ".github/workflows/npm-ci-ts.yml",
+    }
+
+    pkg_json = json.loads((tmp_path / "ts" / "package.json").read_text())
+    assert pkg_json["type"] == "module"
+    assert pkg_json["scripts"]["test"] == "vitest run"
+    assert "tsup" in pkg_json["scripts"]["build"]
+    # Same wads.ci SSOT + publish model as js: validate-always, publish-opt-in.
+    cfg = NpmCIConfig(pkg_json)
+    assert cfg.subdir == "ts"
+    assert cfg.publish_enabled is False
+    assert cfg.publish_marker == "[publish-npm]"
+    assert cfg.provenance is True
+
+    tsconfig = json.loads((tmp_path / "ts" / "tsconfig.json").read_text())
+    assert tsconfig["compilerOptions"]["strict"] is True
+
+    workflow = (tmp_path / ".github" / "workflows" / "npm-ci-ts.yml").read_text()
+    assert "name: NPM CI (ts)" in workflow
+    assert "package-dir: ts" in workflow
+    assert "i2mint/wads/.github/workflows/npm-ci.yml@master" in workflow
+    assert "<<" not in workflow and ">>" not in workflow
+
+
+def test_ts_profile_pnpm_package_manager(tmp_path):
+    apply_frontend(
+        str(tmp_path), profile="ts", project_name="widget", package_manager="pnpm"
+    )
+    pkg_json = json.loads((tmp_path / "ts" / "package.json").read_text())
+    assert NpmCIConfig(pkg_json).package_manager == "pnpm"
+
+
+# --- ts-monorepo profile -------------------------------------------------------
+
+
+def test_ts_monorepo_profile_structure(tmp_path):
+    result = apply_frontend(str(tmp_path), profile="ts-monorepo", project_name="widget")
+    assert set(result.added) == {
+        "ts/package.json",
+        "ts/pnpm-workspace.yaml",
+        "ts/turbo.json",
+        "ts/tsconfig.base.json",
+        "ts/packages/core/package.json",
+        "ts/packages/core/tsconfig.json",
+        "ts/packages/core/src/index.ts",
+        ".github/workflows/npm-ci-ts.yml",
+    }
+
+    root = json.loads((tmp_path / "ts" / "package.json").read_text())
+    assert root["private"] is True
+    assert root["packageManager"].startswith("pnpm@")
+    assert NpmCIConfig(root).package_manager == "pnpm"
+    assert NpmCIConfig(root).publish_enabled is False  # opt-in, same model
+
+    workspace = (tmp_path / "ts" / "pnpm-workspace.yaml").read_text()
+    assert "packages/*" in workspace
+
+    pkg = json.loads(
+        (tmp_path / "ts" / "packages" / "core" / "package.json").read_text()
+    )
+    assert pkg["name"] == "widget"
+
+    # The monorepo stub calls the *monorepo* reusable workflow.
+    workflow = (tmp_path / ".github" / "workflows" / "npm-ci-ts.yml").read_text()
+    assert "i2mint/wads/.github/workflows/npm-ci-monorepo.yml@master" in workflow
+    assert "<<" not in workflow and ">>" not in workflow
+
+
+# --- multiple components coexist without collision -----------------------------
+
+
+def test_js_and_ts_components_no_collision(tmp_path):
+    apply_frontend(str(tmp_path), profile="js", project_name="widget")
+    apply_frontend(str(tmp_path), profile="ts", project_name="widget")
+
+    assert (tmp_path / "js" / "package.json").exists()
+    assert (tmp_path / "ts" / "package.json").exists()
+    workflows = sorted(p.name for p in (tmp_path / ".github" / "workflows").iterdir())
+    assert workflows == ["npm-ci-ts.yml", "npm-ci.yml"]
+
+    js_wf = (tmp_path / ".github" / "workflows" / "npm-ci.yml").read_text()
+    ts_wf = (tmp_path / ".github" / "workflows" / "npm-ci-ts.yml").read_text()
+    assert 'paths:\n      - "js/**"' in js_wf
+    assert 'paths:\n      - "ts/**"' in ts_wf
+
+
+# --- populate --frontend CLI integration --------------------------------------
+
+
+def test_populate_frontend_ts(tmp_path):
+    pkg_dir = tmp_path / "widget"
+    pkg_dir.mkdir()
+    _git_init(pkg_dir, "https://github.com/myorg/widget")
+
+    populate_pkg_dir(
+        str(pkg_dir),
+        description="Has a TS lib",
+        root_url="https://github.com/myorg",
+        version="0.1.0",
+        verbose=False,
+        frontend="ts",
+    )
+    assert (pkg_dir / "pyproject.toml").exists()  # Python side untouched
+    assert (pkg_dir / "ts" / "tsconfig.json").exists()
+    assert (pkg_dir / ".github" / "workflows" / "npm-ci-ts.yml").exists()
+    assert not (pkg_dir / "js").exists()
+
+
+def test_populate_frontend_multi(tmp_path):
+    pkg_dir = tmp_path / "widget"
+    pkg_dir.mkdir()
+    _git_init(pkg_dir, "https://github.com/myorg/widget")
+
+    populate_pkg_dir(
+        str(pkg_dir),
+        description="JS and TS",
+        root_url="https://github.com/myorg",
+        version="0.1.0",
+        verbose=False,
+        frontend="js,ts",
+    )
+    assert (pkg_dir / "js" / "package.json").exists()
+    assert (pkg_dir / "ts" / "package.json").exists()
+    assert (pkg_dir / ".github" / "workflows" / "npm-ci.yml").exists()
+    assert (pkg_dir / ".github" / "workflows" / "npm-ci-ts.yml").exists()
+
+
+def test_populate_with_npm_is_js_alias(tmp_path):
+    pkg_dir = tmp_path / "widget"
+    pkg_dir.mkdir()
+    _git_init(pkg_dir, "https://github.com/myorg/widget")
+
+    populate_pkg_dir(
+        str(pkg_dir),
+        description="Legacy flag",
+        root_url="https://github.com/myorg",
+        version="0.1.0",
+        verbose=False,
+        with_npm=True,
+    )
+    assert (pkg_dir / "js" / "package.json").exists()
+    assert (pkg_dir / ".github" / "workflows" / "npm-ci.yml").exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/wads/tests/test_npm_setup.py
+++ b/wads/tests/test_npm_setup.py
@@ -40,7 +40,11 @@ def test_npm_config_reads_values():
                 "subdir": "frontend",
                 "packageManager": "pnpm",
                 "nodeVersions": ["22"],
-                "publish": {"enabled": True, "marker": "[ship-it]", "access": "restricted"},
+                "publish": {
+                    "enabled": True,
+                    "marker": "[ship-it]",
+                    "access": "restricted",
+                },
             }
         },
     }
@@ -105,7 +109,10 @@ def test_overlay_custom_subdir_and_name(tmp_path):
     pkg_json = json.loads((tmp_path / "frontend" / "package.json").read_text())
     assert pkg_json["name"] == "@acme/proj-ui"
     assert NpmCIConfig(pkg_json).subdir == "frontend"
-    workflow = (tmp_path / ".github" / "workflows" / "npm-ci.yml").read_text()
+    # Per-subdir workflow filename (issue #39): non-"js" subdirs get
+    # ``npm-ci-<subdir>.yml`` so multiple frontend components never collide.
+    # (The "js" subdir keeps the bare ``npm-ci.yml`` — see the byte-compat test.)
+    workflow = (tmp_path / ".github" / "workflows" / "npm-ci-frontend.yml").read_text()
     assert "frontend/**" in workflow
     assert "package-dir: frontend" in workflow
 


### PR DESCRIPTION
Closes #39.

Generalizes the single npm-only overlay (#32) into a small **registry of frontend language/toolchain profiles**, selected per project. The Python `populate` path and the `name/name/` root layout are **untouched** — this is purely additive on the frontend overlay.

## What changed

**Registry** (`wads/profiles.py`)
- `FrontendProfile` dataclass + `FRONTEND_PROFILES` registry, with `register_frontend_profile` / `get_frontend_profile` (open-closed: downstreams can add profiles).
- `apply_frontend(profile=..., ...)` facade. `apply_npm_overlay` / `npm_overlay_*` kept as thin back-compat shims.

**Built-in profiles**
- **`js`** — the original #32 overlay. **Byte-identical** to pre-#39 (golden-pinned in `wads/tests/data/golden/frontend_js/`). Subdir `js/`, single-package `npm-ci.yml`.
- **`ts`** — single-package TypeScript: `tsconfig.json` + `src/index.ts`, tsup build + vitest, same `wads.ci` block + publish model. Subdir `ts/`.
- **`ts-monorepo`** — pnpm workspaces + turbo: private workspace-root `package.json`, `pnpm-workspace.yaml`, `turbo.json`, `tsconfig.base.json`, example `packages/core`.

**Collision-free multi-component**
- The `js` component keeps the bare `npm-ci.yml`; every other component gets `npm-ci-<subdir>.yml`, each path-filtered to its own subdir. A project can declare several components (e.g. `js` + `ts`) without workflow collision.

**New reusable workflow** `.github/workflows/npm-ci-monorepo.yml`
- `setup` discovers workspace packages; `validate` runs turbo lint/test/build matrixed over node; `publish` iterates packages with a per-package version-exists guard. Validate-always / publish-opt-in (`[publish-npm]`), OIDC + provenance — same model as the single-package workflow.

**CLI**
- `populate --frontend <profile>[,<profile>]` (e.g. `--frontend ts`, `--frontend js,ts`). `--with-npm` kept as a back-compat alias for `--frontend js`.

**Docs / tests / skills**
- New `test_frontend_profiles.py` (golden-pinned `js` byte-compat, per-profile, `js`+`ts` no-collision, CLI integration). The one `test_npm_setup.py` assertion that pinned the old single-filename for a non-`js` subdir is realigned to the per-subdir scheme (issue-sanctioned; `js` byte-compat preserved).
- README "Frontend profiles" section; `.claude/CLAUDE.md` registry section; additive `--frontend` guidance in the bundled `setup-py-project` skill.

## Notes
- The pnpm work from `feat/npm-ci-pnpm` is already on master, so pnpm is available as a per-component `packageManager`; that branch is now redundant and can be deleted.
- pnpm `ts-monorepo` reusable workflow validated as well-formed YAML; full Python suite green (259 passed), including the python-lib characterization (Python side unchanged).

## Acceptance (#39)
- [x] Do not touch the Python `populate` path or `name/name/` layout
- [x] `js` profile output byte-compatible (golden-pinned)
- [x] `ts` profile: working single-package setup + npm-ci (validate-always, publish-opt-in)
- [x] `js` + `ts` coexist without workflow collision
- [x] `ts-monorepo` profile implemented (full scope) with its own reusable workflow
- [x] Realign docs, tests, and skills