### PR TITLE
Make ts/ts-monorepo frontend profiles green out of the box (#41)

### DIFF
--- a/.github/workflows/npm-ci-monorepo.yml
+++ b/.github/workflows/npm-ci-monorepo.yml
@@ -100,17 +100,34 @@ jobs:
         node: ${{ fromJson(needs.setup.outputs.node_versions) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Detect lockfile
+        id: lock
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No pnpm-lock.yaml committed in '${{ inputs.package-dir }}'; installing without a frozen lockfile and skipping the dependency cache. Commit a lockfile for reproducible, cached installs."
+          fi
       - uses: pnpm/action-setup@v4
         with:
           package_json_file: ${{ inputs.package-dir }}/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
+          # Only enable the cache when a lockfile is committed (setup-node errors
+          # if cache is on but pnpm-lock.yaml is absent -- issue #41).
+          cache: ${{ steps.lock.outputs.present == 'true' && 'pnpm' || '' }}
           cache-dependency-path: ${{ inputs.package-dir }}/pnpm-lock.yaml
       - name: Install
         working-directory: ${{ inputs.package-dir }}
-        run: pnpm install --frozen-lockfile
+        run: |
+          if [ "${{ steps.lock.outputs.present }}" = "true" ]; then
+            pnpm install --frozen-lockfile
+          else
+            pnpm install --no-frozen-lockfile
+          fi
       - name: Lint
         working-directory: ${{ inputs.package-dir }}
         run: ${{ needs.setup.outputs.lint_command }}
@@ -142,7 +159,7 @@ jobs:
           registry-url: ${{ needs.setup.outputs.registry }}
       - name: Install
         working-directory: ${{ inputs.package-dir }}
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       - name: Build
         working-directory: ${{ inputs.package-dir }}
         run: ${{ needs.setup.outputs.build_command }}

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -108,6 +108,21 @@ jobs:
         node: ${{ fromJson(needs.setup.outputs.node_versions) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Detect lockfile
+        id: lock
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          if [ "${{ needs.setup.outputs.package_manager }}" = "pnpm" ]; then
+            LOCKFILE=pnpm-lock.yaml
+          else
+            LOCKFILE=package-lock.json
+          fi
+          if [ -f "$LOCKFILE" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No $LOCKFILE committed in '${{ inputs.package-dir }}'; installing without a frozen lockfile and skipping the dependency cache. Commit a lockfile for reproducible, cached installs."
+          fi
       - name: Setup pnpm
         if: needs.setup.outputs.package_manager == 'pnpm'
         uses: pnpm/action-setup@v4
@@ -117,13 +132,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: ${{ needs.setup.outputs.package_manager }}
+          # The dependency cache keys off the lockfile; only enable it when one
+          # is committed (setup-node errors if cache is on but the lockfile is
+          # absent -- e.g. a freshly generated project, issue #41).
+          cache: ${{ steps.lock.outputs.present == 'true' && needs.setup.outputs.package_manager || '' }}
           cache-dependency-path: ${{ inputs.package-dir }}/${{ needs.setup.outputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json' }}
       - name: Install
         working-directory: ${{ inputs.package-dir }}
         run: |
           if [ "${{ needs.setup.outputs.package_manager }}" = "pnpm" ]; then
-            pnpm install --frozen-lockfile
+            if [ "${{ steps.lock.outputs.present }}" = "true" ]; then
+              pnpm install --frozen-lockfile
+            else
+              pnpm install --no-frozen-lockfile
+            fi
           else
             npm ci || npm install
           fi
@@ -162,7 +184,7 @@ jobs:
         working-directory: ${{ inputs.package-dir }}
         run: |
           if [ "${{ needs.setup.outputs.package_manager }}" = "pnpm" ]; then
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
           else
             npm ci || npm install
           fi

--- a/wads/__init__.py
+++ b/wads/__init__.py
@@ -44,6 +44,7 @@ github_ci_npm_stub_path = rjoin(data_dir, "github_ci_npm_stub.yml")
 package_json_ts_tpl_path = rjoin(data_dir, "package_json_ts_tpl.json")
 tsconfig_tpl_path = rjoin(data_dir, "tsconfig_tpl.json")
 ts_index_tpl_path = rjoin(data_dir, "ts_index_tpl.ts")
+ts_index_test_tpl_path = rjoin(data_dir, "ts_index_test_tpl.ts")
 # `ts-monorepo` (pnpm workspaces + turbo):
 pnpm_workspace_tpl_path = rjoin(data_dir, "pnpm_workspace_tpl.yaml")
 turbo_tpl_path = rjoin(data_dir, "turbo_tpl.json")

--- a/wads/data/package_json_monorepo_root_tpl.json
+++ b/wads/data/package_json_monorepo_root_tpl.json
@@ -14,6 +14,9 @@
     "turbo": "^2",
     "typescript": "^5"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
   "wads": {
     "ci": {
       "subdir": "<< npm_subdir >>",

--- a/wads/data/package_json_ts_tpl.json
+++ b/wads/data/package_json_ts_tpl.json
@@ -27,6 +27,9 @@
     "typescript": "^5",
     "vitest": "^2"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
   "wads": {
     "ci": {
       "subdir": "<< npm_subdir >>",

--- a/wads/data/ts_index_test_tpl.ts
+++ b/wads/data/ts_index_test_tpl.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { hello } from "./index.js";
+
+describe("hello", () => {
+  it("greets the world by default", () => {
+    expect(hello()).toBe("Hello, world!");
+  });
+
+  it("greets a given name", () => {
+    expect(hello("wads")).toBe("Hello, wads!");
+  });
+});

--- a/wads/profiles.py
+++ b/wads/profiles.py
@@ -33,6 +33,7 @@ from wads import (
     package_json_ts_tpl_path,
     tsconfig_tpl_path,
     ts_index_tpl_path,
+    ts_index_test_tpl_path,
     pnpm_workspace_tpl_path,
     turbo_tpl_path,
     package_json_monorepo_root_tpl_path,
@@ -196,6 +197,9 @@ def _ts_artifacts(ctx: Mapping) -> list:
         _jinja(f"{subdir}/package.json", package_json_ts_tpl_path),
         _copy(f"{subdir}/tsconfig.json", tsconfig_tpl_path),
         _copy(f"{subdir}/src/index.ts", ts_index_tpl_path),
+        # Ship a passing starter test so the `test` step is green out of the
+        # box: `vitest run` exits 1 when it finds *no* test files (issue #41).
+        _copy(f"{subdir}/src/index.test.ts", ts_index_test_tpl_path),
         _stub_artifact(subdir),
     ]
 
@@ -217,6 +221,8 @@ def _ts_monorepo_artifacts(ctx: Mapping) -> list:
         _jinja(f"{pkg_dir}/package.json", package_json_monorepo_pkg_tpl_path),
         _copy(f"{pkg_dir}/tsconfig.json", tsconfig_monorepo_pkg_tpl_path),
         _copy(f"{pkg_dir}/src/index.ts", ts_index_tpl_path),
+        # Passing starter test so `turbo run test` is green out of the box (#41).
+        _copy(f"{pkg_dir}/src/index.test.ts", ts_index_test_tpl_path),
         _stub_artifact(subdir),
     ]
 
@@ -315,8 +321,8 @@ def apply_frontend(
     >>> d = tempfile.mkdtemp()
     >>> res = apply_frontend(d, profile="ts", project_name="widget")
     >>> sorted(res.added)  # doctest: +NORMALIZE_WHITESPACE
-    ['.github/workflows/npm-ci-ts.yml', 'ts/package.json', 'ts/src/index.ts',
-     'ts/tsconfig.json']
+    ['.github/workflows/npm-ci-ts.yml', 'ts/package.json', 'ts/src/index.test.ts',
+     'ts/src/index.ts', 'ts/tsconfig.json']
     """
     prof = get_frontend_profile(profile)
     subdir = subdir or prof.default_subdir

--- a/wads/tests/test_frontend_profiles.py
+++ b/wads/tests/test_frontend_profiles.py
@@ -110,6 +110,7 @@ def test_ts_profile_writes_expected_files(tmp_path):
         "ts/package.json",
         "ts/tsconfig.json",
         "ts/src/index.ts",
+        "ts/src/index.test.ts",
         ".github/workflows/npm-ci-ts.yml",
     }
 
@@ -117,6 +118,14 @@ def test_ts_profile_writes_expected_files(tmp_path):
     assert pkg_json["type"] == "module"
     assert pkg_json["scripts"]["test"] == "vitest run"
     assert "tsup" in pkg_json["scripts"]["build"]
+    # esbuild build-script allowlist so pnpm >=10 can build tsup's esbuild (#41).
+    assert pkg_json["pnpm"]["onlyBuiltDependencies"] == ["esbuild"]
+
+    # A passing starter test ships so the `test` step is green out of the box
+    # (vitest exits 1 with no test files, issue #41).
+    test_src = (tmp_path / "ts" / "src" / "index.test.ts").read_text()
+    assert "vitest" in test_src and "hello" in test_src
+
     # Same wads.ci SSOT + publish model as js: validate-always, publish-opt-in.
     cfg = NpmCIConfig(pkg_json)
     assert cfg.subdir == "ts"
@@ -155,6 +164,7 @@ def test_ts_monorepo_profile_structure(tmp_path):
         "ts/packages/core/package.json",
         "ts/packages/core/tsconfig.json",
         "ts/packages/core/src/index.ts",
+        "ts/packages/core/src/index.test.ts",
         ".github/workflows/npm-ci-ts.yml",
     }
 
@@ -162,6 +172,8 @@ def test_ts_monorepo_profile_structure(tmp_path):
     assert root["private"] is True
     assert root["packageManager"].startswith("pnpm@")
     assert NpmCIConfig(root).package_manager == "pnpm"
+    # esbuild build-script allowlist for pnpm >=10 (#41).
+    assert root["pnpm"]["onlyBuiltDependencies"] == ["esbuild"]
     assert NpmCIConfig(root).publish_enabled is False  # opt-in, same model
 
     workspace = (tmp_path / "ts" / "pnpm-workspace.yaml").read_text()


### PR DESCRIPTION
Closes #41.

First real end-to-end validation of the `ts` / `ts-monorepo` frontend profiles added in #39/#40. I scaffolded throwaway projects and ran the actual toolchain (node 23, npm 10, pnpm 9.12.0 = the pinned CI version, and pnpm 10.14.0). Three out-of-the-box CI failures surfaced; this PR fixes all three.

## A — empty test step failed CI *(real, both profiles)*
`package.json` shipped `"test": "vitest run"` but no test files; `vitest run` exits **1** with no tests. `npm test --if-present` doesn't save it (the script *is* present).
**Fix:** ship a passing starter `src/index.test.ts` (asserts the generated `hello()` export) for both `ts` and the monorepo `packages/core`.

## C — no committed lockfile → CI hard-failed *(real, both profiles)*
`actions/setup-node` errors when `cache:` is set but the lockfile is absent, and the pnpm path used `pnpm install --frozen-lockfile`. A freshly generated project ships no lockfile.
**Fix:** both reusable workflows now detect the lockfile, gate the dependency cache on its presence, and install non-frozen when none is committed. **No behaviour change** for consumers that commit a lockfile (cache + `--frozen-lockfile` as before).

## B — pnpm ≥10 blocks esbuild's build script *(forward-compat only)*
Not a live failure: the monorepo pins `packageManager: pnpm@9.12.0`, and pnpm 9 runs build scripts. But a bump to pnpm ≥10 would break `tsup`→`esbuild`.
**Fix (verified on pnpm 10.14.0):** add `"pnpm": { "onlyBuiltDependencies": ["esbuild"] }` to the monorepo-root and single-`ts` `package.json` templates.

## Validation
| Scaffold | Result |
|---|---|
| `ts` + npm | install / build (tsup→dist) / lint (tsc --noEmit) / **test (2 passed)** ✅ |
| `ts-monorepo` + pnpm@9.12.0 | install (esbuild builds) / turbo build+test+lint ✅ |
| `ts-monorepo` + pnpm@10.14.0 | install (esbuild builds w/ allowlist) / turbo build+test ✅ |

The install side of Snag C is proven locally (all runs above had **no committed lockfile**). The setup-node cache-gating half only executes on a GitHub runner — its first live exercise will be walkthru's adoption of `wads --frontend ts`.

Full suite green (261 passed, incl. the `apply_frontend` doctest). `js` golden untouched (no `js` template/output change).