### PR TITLE
Drop SSH push-back detour from inline github_ci_uv.yml template

### DIFF
--- a/wads/data/github_ci_uv.yml
+++ b/wads/data/github_ci_uv.yml
@@ -180,6 +180,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # `actions/checkout@v6` defaults to persist-credentials: true, configuring
+      # HTTPS auth in .git/config using `secrets.GITHUB_TOKEN`. Together with the
+      # job-level `permissions: contents: write`, this is exactly what the
+      # post-publish push-back needs — no per-repo SSH deploy key required. Do
+      # NOT re-add a "Force SSH for git remote" step: rewriting origin to an
+      # SSH URL overrides these credentials and reintroduces the push-back
+      # failure on every repo lacking an SSH_PRIVATE_KEY deploy key.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -217,14 +224,10 @@ jobs:
         with:
           pypi-token: ${{ secrets.PYPI_PASSWORD }}
 
-      - name: Force SSH for git remote
-        run: git remote set-url origin git@github.com:${{ github.repository }}.git
-
       - name: Commit Changes
         uses: i2mint/wads/actions/git-commit@master
         with:
           commit-message: "**CI** Formatted code + Updated version to ${{ env.VERSION }} [skip ci]"
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           push: true
 
       - name: Tag Repository


### PR DESCRIPTION
Closes #43.

## What

Removes the two SSH push-back remnants from the inline uv CI template `wads/data/github_ci_uv.yml` so it matches the already-working reusable workflow (`.github/workflows/uv-ci.yml`):

- deleted the `Force SSH for git remote` step (was rewriting `origin` to `git@github.com:…`, overriding the HTTPS+token credentials);
- removed `ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}` from the `Commit Changes` step;
- added a comment on the checkout step warning against re-adding an SSH override.

## Why

The template was half-migrated: the publish job already checks out with `token: ${{ secrets.GITHUB_TOKEN }}` + `fetch-depth: 0` and declares `permissions: contents: write`, but the leftover SSH override defeated all of that — re-pointing the remote at SSH and routing `git-commit` through the ssh-agent path. Net result for any repo on the inline template (the documented escape valve, also produced by `wads-migrate ci-to-uv`): the original auto-bump push-back failure (PyPI ends up ahead of `pyproject.toml`) unless that repo happened to set an `SSH_PRIVATE_KEY` deploy key.

`git-commit`'s ssh-agent step is gated on `if: ${{ inputs.ssh-private-key }}`, so with the input gone it does a plain `git push` over the token-authenticated HTTPS remote.

## Test

`wads/tests/test_uv_workflow_template.py` — 46 passed (asserts none of the removed lines; the `TestUvMigration` cases that read this template stay green).

## Scope

Focused on the live uv push-back path only. Other legacy templates still referencing `SSH_PRIVATE_KEY` (`github_ci_publish_2025.yml`, `github_ci_tpl_publish.yml`, `gitlab_ci_tpl.yml`) are intentionally left untouched.
