### PR TITLE
Drive CI secrets/env from pyproject.toml (closes #45)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,6 +112,33 @@ most customization belongs in `[tool.wads.ci.*]`), it can replace the stub with
 a copy of `wads/data/github_ci_uv.yml` inline. The repo then owns CI updates
 manually. Convert back to stub later with `wads-migrate ci-to-stub`.
 
+### Secrets / CI env vars — two layers (issue #45)
+
+A reusable workflow's secret *interface* (`on.workflow_call.secrets`) must be
+static YAML and `secrets: inherit` is unreliable cross-owner, so secrets are
+handled in two decoupled layers:
+
+1. **Transport** — the caller stub *explicitly passes* named secrets. The
+   universe of passable names is the **superset** declared in `uv-ci.yml`'s
+   `on.workflow_call.secrets`, generated from `wads.ci_secrets.DEFAULT_CI_SECRETS`
+   (the SSOT; a test in `test_ci_secrets.py` pins the YAML to it). Each repo's
+   stub passes only a *small subset* — `PYPI_PASSWORD` plus whatever its
+   `[tool.wads.ci.env]` declares (rendered via `CIConfig.generate_stub_secrets_block`
+   into the stub's `#SECRETS_BLOCK#` placeholder at populate/migrate time).
+2. **Env-assignment** — *which* passed secrets become job env vars (and which
+   are required) is driven entirely by `[tool.wads.ci.env]` (`required_envvars`,
+   `test_envvars`, `extra_envvars`, `defaults`, and `secret_aliases` for
+   ENV_VAR≠SECRET_NAME). The `export-ci-env` action (`wads/scripts/export_ci_env.py`)
+   reads these via `read-ci-config` outputs and `toJSON(secrets)`, writes exactly
+   the declared vars to `$GITHUB_ENV`, and **fails fast** on a missing required
+   secret. A passed-but-undeclared secret is never written to the environment —
+   so no over-assignment, and no silent under-coverage.
+
+To use a secret: `wads-secrets add VAR_NAME [SECRET_NAME]` updates both layers
+(pyproject + stub) and can `gh secret set` the value. A name outside the superset
+needs a one-line PR to `wads.ci_secrets` (or the inline escape valve); the CLI
+warns when that's the case.
+
 ### CI Workflow Flow (github_ci_publish_2025.yml)
 
 The CI workflow has 4-5 jobs:
@@ -229,6 +256,14 @@ wads-migrate setup-to-pyproject setup.cfg
 
 # Migrate old CI → new CI
 wads-migrate ci-old-to-new .github/workflows/ci.yml
+
+# Configure a CI secret (declare in pyproject + pass in ci.yml + gh secret set)
+wads-secrets add OPENAI_API_KEY                  # var == secret name
+wads-secrets add HF_TOKEN HF_WRITE_TOKEN          # env var <- aliased secret
+wads-secrets add DB_URL --kind required           # fail CI if unset
+wads-secrets add OPENAI_API_KEY --no-github       # edit files only
+wads-secrets list                                 # show configured env vars
+wads-secrets superset                             # names the stub may pass
 
 # Debug CI failures
 wads-ci-debug myorg/myrepo --fix

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -1,53 +1,102 @@
 name: Continuous Integration (uv, reusable)
-# Reusable wads CI workflow. Consuming repos call this via a 5-line stub at
+# Reusable wads CI workflow. Consuming repos call this via a small stub at
 # .github/workflows/ci.yml — see wads/data/github_ci_uv_stub.yml.
 #
 # All configuration comes from the caller's pyproject.toml [tool.wads.ci.*]
-# section, read by the setup job below. Caller passes `secrets: inherit` so
-# this workflow can use PYPI_PASSWORD, GITHUB_TOKEN, and the curated set of
-# secret-backed env vars in the workflow-level env block.
+# section, read by the setup job below.
 #
-# If a repo needs a workflow-level env var that isn't in the curated set,
-# the right answer is to add it here via a PR to wads (so every consumer
-# benefits) — OR, for a one-off, to inline the full workflow (escape valve)
-# by replacing the stub with a copy of wads/data/github_ci_uv.yml.
+# SECRETS — two layers (see wads/ci_secrets.py for the full rationale):
+#   1. Transport: the caller stub explicitly passes named secrets (cross-owner
+#      `secrets: inherit` is unreliable, so we never rely on it). The
+#      `on.workflow_call.secrets` block below is the *superset* of names a
+#      stub may pass — the universe of allowed secret names. It is generated
+#      from wads.ci_secrets.DEFAULT_CI_SECRETS and pinned by a wads test.
+#   2. Env-assignment: which of those secrets actually become job environment
+#      variables (and which are required) is driven entirely by the caller's
+#      [tool.wads.ci.env], applied by the `export-ci-env` action below. A
+#      passed-but-unconfigured secret is never written to the environment.
+#
+# To use a secret whose name is NOT in the superset below: either add it here
+# via a PR to wads (one line, benefits everyone) or inline the full workflow
+# (escape valve) by replacing the stub with a copy of wads/data/github_ci_uv.yml.
 
 on:
   workflow_call:
     inputs:
       # Most consumers don't need to override anything — pyproject.toml drives
       # the workflow. These inputs exist for the rare cases where the project
-      # name differs from the repo name, or where the consumer wants to pass
-      # additional env vars without forking the workflow.
+      # name differs from the repo name.
       project-name:
         description: "Project / package name. Defaults to the repo name."
         type: string
         required: false
         default: ""
 
-    # Explicitly declare the secrets the reusable workflow consumes.
-    # `secrets: inherit` on the caller stub satisfies every entry below
-    # whenever the caller's repo (or org) has that secret defined; missing
-    # secrets resolve to empty strings inside this workflow (the env block
-    # below uses `|| ''` to be safe).
-    #
-    # WHY we declare instead of relying on implicit inheritance: GitHub's
-    # `secrets: inherit` semantics are documented to pass all caller secrets
-    # to the called workflow, but in practice that propagation is unreliable
-    # when the caller and called workflows live under different owners
-    # (e.g. caller in a personal account, called in an org). Personal-account
-    # callers got `${{ secrets.PYPI_PASSWORD }}` resolving to empty in the
-    # publish step, while same-org callers worked. Explicit declaration
-    # removes that ambiguity for every caller type.
+    # ─── SECRET SUPERSET (generated from wads.ci_secrets.DEFAULT_CI_SECRETS) ───
+    # Every entry is `required: false`; the caller stub passes only the subset
+    # its pyproject declares. Run-time enforcement of required secrets happens
+    # in the export-ci-env step (and PYPI_PASSWORD in the publish job).
+    # Edit wads/ci_secrets.py, not this block by hand — a test pins them equal.
     secrets:
       PYPI_PASSWORD:
-        description: "PyPI API token. Required for the publish job."
+        required: false
+      TEST_PYPI_PASSWORD:
+        required: false
+      NPM_TOKEN:
+        required: false
+      SSH_PRIVATE_KEY:
+        required: false
+      CODECOV_TOKEN:
+        required: false
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
         required: false
       OPENAI_API_KEY:
         required: false
       ANTHROPIC_API_KEY:
         required: false
+      GEMINI_API_KEY:
+        required: false
+      GOOGLE_API_KEY:
+        required: false
+      DEEPSEEK_API_KEY:
+        required: false
+      OPENROUTER_API_KEY:
+        required: false
+      GROQ_API_KEY:
+        required: false
+      MISTRAL_API_KEY:
+        required: false
+      COHERE_API_KEY:
+        required: false
+      PERPLEXITY_API_KEY:
+        required: false
+      REPLICATE_API_TOKEN:
+        required: false
+      TOGETHER_API_KEY:
+        required: false
+      XAI_API_KEY:
+        required: false
+      FAL_KEY:
+        required: false
+      AZURE_OPENAI_API_KEY:
+        required: false
+      AZURE_OPENAI_ENDPOINT:
+        required: false
+      TAVILY_API_KEY:
+        required: false
+      COMPOSIO_API_KEY:
+        required: false
+      SKILLSDIRECTORY_API_KEY:
+        required: false
+      NEWSDATA_API_KEY:
+        required: false
+      LANGSMITH_API_KEY:
+        required: false
       HF_TOKEN:
+        required: false
+      HF_WRITE_TOKEN:
         required: false
       HUGGINGFACE_TOKEN:
         required: false
@@ -55,23 +104,74 @@ on:
         required: false
       KAGGLE_KEY:
         required: false
+      WANDB_API_KEY:
+        required: false
+      PINECONE_API_KEY:
+        required: false
+      ELEVEN_API_KEY:
+        required: false
+      ELEVENLABS_API_KEY:
+        required: false
+      SUNO_API_KEY:
+        required: false
+      SPOTIFY_API_CLIENT_ID:
+        required: false
+      SPOTIFY_API_CLIENT_SECRET:
+        required: false
+      SPOTIPY_CLIENT_ID:
+        required: false
+      SPOTIPY_CLIENT_SECRET:
+        required: false
+      ALPACA_API_KEY:
+        required: false
+      ALPACA_SECRET_KEY:
+        required: false
+      APCA_API_KEY_ID:
+        required: false
+      APCA_API_SECRET_KEY:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AWS_SESSION_TOKEN:
+        required: false
+      GCP_SA_KEY:
+        required: false
+      GOOGLE_APPLICATION_CREDENTIALS_JSON:
+        required: false
+      SLACK_BOT_TOKEN:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
+      DISCORD_WEBHOOK_URL:
+        required: false
+      TELEGRAM_BOT_TOKEN:
+        required: false
+      TWILIO_ACCOUNT_SID:
+        required: false
+      TWILIO_AUTH_TOKEN:
+        required: false
+      SENDGRID_API_KEY:
+        required: false
+      STRIPE_SECRET_KEY:
+        required: false
+      DATABASE_URL:
+        required: false
+      MONGODB_URI:
+        required: false
+      REDIS_URL:
+        required: false
 
 env:
   # Project identification. Most repos: package name == repo name; this just
   # resolves to github.event.repository.name. Override with `with.project-name`
   # in the caller stub when they differ.
+  #
+  # NOTE: secret-backed env vars are intentionally NOT set here. They are
+  # written to $GITHUB_ENV per-job by the export-ci-env step, driven by the
+  # caller's [tool.wads.ci.env] — so each repo gets exactly the env it declares.
   PROJECT_NAME: ${{ inputs.project-name != '' && inputs.project-name || github.event.repository.name }}
-
-  # Curated set of secret-backed env vars used across the wads-managed
-  # ecosystem. Falls back to '' when the caller's repo doesn't have the
-  # secret set, so missing secrets don't fail YAML parsing. Add new common
-  # ones via PR to wads (see wads/data/github_ci_uv_stub.yml for the rationale).
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
-  HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}
-  HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN || '' }}
-  KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME || '' }}
-  KAGGLE_KEY: ${{ secrets.KAGGLE_KEY || '' }}
 
 jobs:
   # First job: Read configuration from pyproject.toml
@@ -101,6 +201,11 @@ jobs:
       publish-enabled: ${{ steps.config.outputs.publish-enabled }}
       skip-ci-marker: ${{ steps.config.outputs.skip-ci-marker }}
       publish-marker: ${{ steps.config.outputs.publish-marker }}
+      env-required: ${{ steps.config.outputs.env-required }}
+      env-test: ${{ steps.config.outputs.env-test }}
+      env-extra: ${{ steps.config.outputs.env-extra }}
+      env-defaults: ${{ steps.config.outputs.env-defaults }}
+      env-aliases: ${{ steps.config.outputs.env-aliases }}
 
     steps:
       - uses: actions/checkout@v6
@@ -149,6 +254,18 @@ jobs:
         uses: i2mint/wads/actions/install-deps-uv@master
         with:
           extras: ${{ needs.setup.outputs.install-extras }}
+
+      # Write the pyproject-declared env vars into $GITHUB_ENV (and fail fast
+      # if a required secret is missing). Driven by [tool.wads.ci.env].
+      - name: Export CI Environment
+        uses: i2mint/wads/actions/export-ci-env@master
+        with:
+          required: ${{ needs.setup.outputs.env-required }}
+          test: ${{ needs.setup.outputs.env-test }}
+          extra: ${{ needs.setup.outputs.env-extra }}
+          defaults: ${{ needs.setup.outputs.env-defaults }}
+          aliases: ${{ needs.setup.outputs.env-aliases }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Format Source Code
         if: needs.setup.outputs.ruff-enabled != 'false'
@@ -221,6 +338,16 @@ jobs:
         uses: i2mint/wads/actions/install-deps-uv@master
         with:
           extras: ${{ needs.setup.outputs.install-extras }}
+
+      - name: Export CI Environment
+        uses: i2mint/wads/actions/export-ci-env@master
+        with:
+          required: ${{ needs.setup.outputs.env-required }}
+          test: ${{ needs.setup.outputs.env-test }}
+          extra: ${{ needs.setup.outputs.env-extra }}
+          defaults: ${{ needs.setup.outputs.env-defaults }}
+          aliases: ${{ needs.setup.outputs.env-aliases }}
+          secrets-json: ${{ toJSON(secrets) }}
 
       - name: Run Tests
         uses: i2mint/wads/actions/run-tests-uv@master

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -1,0 +1,59 @@
+name: 'Export CI Environment from pyproject.toml'
+description: >-
+  Write the pyproject-declared environment variables into $GITHUB_ENV. Exports
+  only the secrets a repo's [tool.wads.ci.env] declares (plus literal defaults),
+  and fails with a clear message if a required secret is missing. The full
+  secrets context is passed via toJSON(secrets) so no per-secret enumeration is
+  needed here — the transport superset is enumerated in the workflow's
+  on.workflow_call.secrets block instead.
+branding:
+  icon: 'lock'
+  color: 'blue'
+
+inputs:
+  required:
+    description: 'JSON array of required env-var names (read-ci-config env-required).'
+    required: false
+    default: '[]'
+  test:
+    description: 'JSON array of test env-var names (read-ci-config env-test).'
+    required: false
+    default: '[]'
+  extra:
+    description: 'JSON array of optional env-var names (read-ci-config env-extra).'
+    required: false
+    default: '[]'
+  defaults:
+    description: 'JSON object of literal default env vars (read-ci-config env-defaults).'
+    required: false
+    default: '{}'
+  aliases:
+    description: 'JSON object mapping env-var name -> secret name (read-ci-config env-aliases).'
+    required: false
+    default: '{}'
+  secrets-json:
+    description: 'The secrets context as JSON. Pass `${{ toJSON(secrets) }}`.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python for env export
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install wads (for CI env utilities)
+      shell: bash
+      run: python -m pip install --quiet 'wads>=0.2.0'
+
+    - name: Export configured environment
+      shell: bash
+      env:
+        WADS_ENV_REQUIRED: ${{ inputs.required }}
+        WADS_ENV_TEST: ${{ inputs.test }}
+        WADS_ENV_EXTRA: ${{ inputs.extra }}
+        WADS_ENV_DEFAULTS: ${{ inputs.defaults }}
+        WADS_ENV_ALIASES: ${{ inputs.aliases }}
+        WADS_SECRETS_JSON: ${{ inputs.secrets-json }}
+      run: python -m wads.scripts.export_ci_env

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -45,7 +45,12 @@ runs:
 
     - name: Install wads (for CI env utilities)
       shell: bash
-      run: python -m pip install --quiet 'wads>=0.2.0'
+      # Install the latest published wads (floor is a version that exists, NOT
+      # the one that first shipped this module — pinning a not-yet-published
+      # version would make `pip install` fail during the publish-lag window
+      # after a wads merge). The run step below no-ops if the installed wads is
+      # too old to contain export_ci_env, so it is safe across that window.
+      run: python -m pip install --quiet --upgrade 'wads>=0.1.48'
 
     - name: Export configured environment
       shell: bash
@@ -56,4 +61,9 @@ runs:
         WADS_ENV_DEFAULTS: ${{ inputs.defaults }}
         WADS_ENV_ALIASES: ${{ inputs.aliases }}
         WADS_SECRETS_JSON: ${{ inputs.secrets-json }}
-      run: python -m wads.scripts.export_ci_env
+      run: |
+        if python -c "import wads.scripts.export_ci_env" 2>/dev/null; then
+          python -m wads.scripts.export_ci_env
+        else
+          echo "::notice::installed wads lacks export_ci_env (pre-0.1.100); skipping env export until wads publishes."
+        fi

--- a/actions/read-ci-config/action.yml
+++ b/actions/read-ci-config/action.yml
@@ -77,6 +77,21 @@ outputs:
   publish-marker:
     description: 'Commit-message substring that forces the publish job even when publishing is disabled. Defaults to "[publish]". Set via [tool.wads.ci.publish].publish_marker.'
     value: ${{ steps.config.outputs.publish-marker }}
+  env-required:
+    description: 'JSON array of required env-var names from [tool.wads.ci.env].required_envvars. CI fails if any is not set in secrets.'
+    value: ${{ steps.config.outputs.env-required }}
+  env-test:
+    description: 'JSON array of test env-var names from [tool.wads.ci.env].test_envvars. CI warns (does not fail) if missing.'
+    value: ${{ steps.config.outputs.env-test }}
+  env-extra:
+    description: 'JSON array of optional env-var names from [tool.wads.ci.env].extra_envvars. Exported if set; silent if missing.'
+    value: ${{ steps.config.outputs.env-extra }}
+  env-defaults:
+    description: 'JSON object of literal default env vars from [tool.wads.ci.env].defaults. Always exported.'
+    value: ${{ steps.config.outputs.env-defaults }}
+  env-aliases:
+    description: 'JSON object mapping env-var name -> backing secret name from [tool.wads.ci.env].secret_aliases. Env vars not listed are backed by an identically-named secret.'
+    value: ${{ steps.config.outputs.env-aliases }}
 
 runs:
   using: 'composite'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ create = [
     "build",         # PEP 517 build (publish)
     "wheel",         # wheel building (publish)
     "ruamel.yaml",   # round-tripping GitHub Actions YAML (CI migration tools)
+    "tomlkit",       # comment-preserving pyproject edits (wads-secrets)
 ]
 docs = ["epythet"]
 test = ["pytest>=7.0", "pytest-cov"]
@@ -50,6 +51,7 @@ wads-deps = "wads.agents.dependency_resolver:main"
 wads-test-analyze = "wads.agents.test_analyzer:main"
 wads-migrate = "wads.migration:main"
 wads-install-skills = "wads.install_skills:main"
+wads-secrets = "wads.secrets_cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["wads"]

--- a/wads/ci_config.py
+++ b/wads/ci_config.py
@@ -141,6 +141,42 @@ class CIConfig:
         """Get default environment variables."""
         return self.ci_config.get("env", {}).get("defaults", {})
 
+    def stub_secret_names(self, *, always=("PYPI_PASSWORD",)) -> list[str]:
+        """GitHub *secret* names the caller stub should pass to the reusable workflow.
+
+        This is the per-repo transport list (kept small): ``PYPI_PASSWORD`` (for
+        the publish job) plus the backing secret of every env var the repo
+        declares in ``[tool.wads.ci.env]`` (required/test/extra), resolved
+        through ``secret_aliases``. Order-preserving, de-duplicated.
+        """
+        from wads.ci_secrets import _dedupe_preserving_order
+
+        aliases = self.env_secret_aliases
+        names = list(always)
+        for var in self.env_vars_all:
+            names.append(aliases.get(var, var))
+        return list(_dedupe_preserving_order(names))
+
+    def generate_stub_secrets_block(self) -> str:
+        """Render the caller-stub ``secrets:`` pass-through for this repo."""
+        from wads.ci_secrets import render_stub_secrets_passthrough
+
+        return render_stub_secrets_passthrough(self.stub_secret_names())
+
+    @property
+    def env_secret_aliases(self) -> dict[str, str]:
+        """Map of env-var name -> backing GitHub *secret* name.
+
+        Lets a repo expose a secret under a different env-var name in CI, e.g.
+        read ``secrets.HF_WRITE_TOKEN`` but expose it to tests as ``HF_TOKEN``::
+
+            [tool.wads.ci.env.secret_aliases]
+            HF_TOKEN = "HF_WRITE_TOKEN"
+
+        Env-var names not listed here are backed by an identically-named secret.
+        """
+        return self.ci_config.get("env", {}).get("secret_aliases", {})
+
     # ✅ CODE QUALITY AND FORMATTING
     @property
     def quality_config(self) -> dict:
@@ -601,6 +637,7 @@ class CIConfig:
         return {
             "#ENV_BLOCK#": self.generate_env_block(),
             "#ENV_VARS#": self.generate_env_vars_yaml(),
+            "#SECRETS_BLOCK#": self.generate_stub_secrets_block(),
             "#PYTHON_VERSIONS#": json.dumps(self.python_versions),
             "#PRE_TEST_STEPS#": self.generate_pre_test_steps(),
             "#EXCLUDE_PATHS#": ",".join(self.exclude_paths),

--- a/wads/ci_secrets.py
+++ b/wads/ci_secrets.py
@@ -1,0 +1,286 @@
+"""Canonical registry of CI secret names for wads-managed projects.
+
+This module is the **single source of truth** for the *transport superset*: the
+set of secret names that the reusable wads CI workflow (``uv-ci.yml``) declares
+in ``on.workflow_call.secrets`` and that the caller stub
+(``github_ci_uv_stub.yml``) passes through.
+
+Why a superset, and why it lives here
+--------------------------------------
+A GitHub *reusable* workflow's secret interface (``on.workflow_call.secrets``)
+must be **static YAML** — it is parsed before any job runs and cannot be
+parametrized from ``pyproject.toml``. ``secrets: inherit`` is documented to work
+only when caller and callee share an owner (org/enterprise), so it is unusable
+for personal-account repos calling an ``i2mint``-owned workflow. The robust,
+universal choice is therefore to *explicitly pass a generous static superset*.
+
+Passing a superset is harmless: a secret the caller has not set resolves to an
+empty string and — crucially — is **not** written into the job environment.
+*Which* secrets actually land in the job env (and which are required) is a
+separate, dynamic decision driven by ``[tool.wads.ci.env]`` in the consumer's
+``pyproject.toml`` (see :mod:`wads.ci_config` and the ``export-ci-env`` action).
+
+So there are two layers:
+
+* **Transport** — the superset below, rendered into static YAML. Plumbing.
+* **Env-assignment** — pyproject-driven, exact, per-repo. The thing users tune.
+
+Keeping the list here (Python) and *rendering* it into the YAML (with a test
+pinning the YAML to this list) gives a single SSOT while respecting GitHub's
+parse-time-literal constraint.
+"""
+
+import re
+
+# ---------------------------------------------------------------------------
+# The canonical superset.
+#
+# Grouped only for human readability; the public value is the flat, de-duped,
+# order-preserving tuple ``DEFAULT_CI_SECRETS`` built below. Widening this list
+# is a one-line PR that benefits every wads-managed repo — over-listing is
+# harmless (unset secrets are empty and never exported), so err toward
+# inclusion of widely-used names.
+# ---------------------------------------------------------------------------
+
+_PUBLISHING = (
+    "PYPI_PASSWORD",  # wads-historical name; it is a PyPI *token*. Required to publish.
+    "TEST_PYPI_PASSWORD",
+    "NPM_TOKEN",
+    "SSH_PRIVATE_KEY",
+    "CODECOV_TOKEN",
+    "DOCKERHUB_USERNAME",
+    "DOCKERHUB_TOKEN",
+)
+
+_LLM_AND_AI = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "COHERE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "REPLICATE_API_TOKEN",
+    "TOGETHER_API_KEY",
+    "XAI_API_KEY",
+    "FAL_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+)
+
+_AGENT_AND_SEARCH = (
+    "TAVILY_API_KEY",
+    "COMPOSIO_API_KEY",
+    "SKILLSDIRECTORY_API_KEY",
+    "NEWSDATA_API_KEY",
+    "LANGSMITH_API_KEY",
+)
+
+_HUGGINGFACE_AND_DATA = (
+    "HF_TOKEN",
+    "HF_WRITE_TOKEN",  # custom; HF's own convention is HF_TOKEN.
+    "HUGGINGFACE_TOKEN",  # legacy alias of HF_TOKEN.
+    "KAGGLE_USERNAME",
+    "KAGGLE_KEY",
+    "WANDB_API_KEY",
+    "PINECONE_API_KEY",
+)
+
+_AUDIO_AND_MEDIA = (
+    "ELEVEN_API_KEY",  # user's spelling
+    "ELEVENLABS_API_KEY",  # official SDK env var
+    "SUNO_API_KEY",  # third-party; no official API convention
+    "SPOTIFY_API_CLIENT_ID",  # user's spelling
+    "SPOTIFY_API_CLIENT_SECRET",
+    "SPOTIPY_CLIENT_ID",  # spotipy's official env vars
+    "SPOTIPY_CLIENT_SECRET",
+)
+
+_FINANCE = (
+    "ALPACA_API_KEY",  # user's spelling
+    "ALPACA_SECRET_KEY",
+    "APCA_API_KEY_ID",  # alpaca-py's official env vars
+    "APCA_API_SECRET_KEY",
+)
+
+_CLOUD = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "GCP_SA_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+)
+
+_MESSAGING_AND_STORAGE = (
+    "SLACK_BOT_TOKEN",
+    "SLACK_WEBHOOK_URL",
+    "DISCORD_WEBHOOK_URL",
+    "TELEGRAM_BOT_TOKEN",
+    "TWILIO_ACCOUNT_SID",
+    "TWILIO_AUTH_TOKEN",
+    "SENDGRID_API_KEY",
+    "STRIPE_SECRET_KEY",
+    "DATABASE_URL",
+    "MONGODB_URI",
+    "REDIS_URL",
+)
+
+_GROUPS = (
+    _PUBLISHING,
+    _LLM_AND_AI,
+    _AGENT_AND_SEARCH,
+    _HUGGINGFACE_AND_DATA,
+    _AUDIO_AND_MEDIA,
+    _FINANCE,
+    _CLOUD,
+    _MESSAGING_AND_STORAGE,
+)
+
+
+def _dedupe_preserving_order(names):
+    """Yield names once each, preserving first-seen order.
+
+    >>> list(_dedupe_preserving_order(["A", "B", "A", "C", "B"]))
+    ['A', 'B', 'C']
+    """
+    seen = set()
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            yield name
+
+
+DEFAULT_CI_SECRETS = tuple(
+    _dedupe_preserving_order(name for group in _GROUPS for name in group)
+)
+"""Ordered, de-duplicated superset of CI secret names (the SSOT)."""
+
+
+# ---------------------------------------------------------------------------
+# Name normalization / validation
+# ---------------------------------------------------------------------------
+
+# A valid GitHub Actions secret / env-var name. GitHub additionally reserves the
+# ``GITHUB_`` prefix for its own secrets, which we reject explicitly below.
+_VALID_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+# Characters allowed in a *name-like* input before normalization. Anything else
+# (``/``, ``+``, ``=``, ``:`` ...) signals a pasted secret *value*, which we
+# refuse — the whole point of forcing UPPER_SNAKE names is to make it hard to
+# accidentally commit a secret value.
+_NAMELIKE_RE = re.compile(r"^[A-Za-z0-9_.\- ]+$")
+
+_MAX_NAME_LEN = 64
+
+
+class InvalidSecretName(ValueError):
+    """Raised when a string cannot be a safe, valid secret/env-var name."""
+
+
+def normalize_secret_name(name: str) -> str:
+    """Force ``name`` to a valid ``UPPER_SNAKE`` secret/env-var name.
+
+    Hyphens, dots and spaces become underscores; the result is upper-cased.
+    Inputs that look like a *value* rather than a *name* are rejected, to guard
+    against accidentally committing a secret value.
+
+    >>> normalize_secret_name("my-api.key")
+    'MY_API_KEY'
+    >>> normalize_secret_name("OPENAI_API_KEY")
+    'OPENAI_API_KEY'
+    >>> normalize_secret_name("  hf token  ")
+    'HF_TOKEN'
+
+    Rejects value-looking and reserved inputs:
+
+    >>> normalize_secret_name("sk-proj-aBc/123+xyz=")  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    InvalidSecretName: ...
+    >>> normalize_secret_name("GITHUB_TOKEN")  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    InvalidSecretName: ...
+    """
+    if not isinstance(name, str):
+        raise InvalidSecretName(f"secret name must be a string, got {type(name)}")
+    stripped = name.strip()
+    if not stripped:
+        raise InvalidSecretName("secret name must not be empty")
+    if len(stripped) > _MAX_NAME_LEN:
+        raise InvalidSecretName(
+            f"{stripped[:12]!r}... is too long to be a name ({len(stripped)} > "
+            f"{_MAX_NAME_LEN}); did you paste a secret value?"
+        )
+    if not _NAMELIKE_RE.match(stripped):
+        raise InvalidSecretName(
+            f"{name!r} contains characters not allowed in a name; "
+            "did you paste a secret value? (names use letters, digits, _ - . space)"
+        )
+    normalized = re.sub(r"[\s.\-]+", "_", stripped).upper()
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    if not _VALID_NAME_RE.match(normalized):
+        raise InvalidSecretName(f"{name!r} does not normalize to a valid name")
+    if normalized.startswith("GITHUB_"):
+        raise InvalidSecretName(
+            "the GITHUB_ prefix is reserved by GitHub; GITHUB_TOKEN is provided "
+            "automatically and must not be declared as a CI secret"
+        )
+    return normalized
+
+
+def is_valid_secret_name(name: str) -> bool:
+    """Return ``True`` iff ``name`` is already a safe, valid secret name.
+
+    >>> is_valid_secret_name("OPENAI_API_KEY")
+    True
+    >>> is_valid_secret_name("my-key")
+    False
+    >>> is_valid_secret_name("GITHUB_TOKEN")
+    False
+    """
+    try:
+        return normalize_secret_name(name) == name
+    except InvalidSecretName:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# YAML renderers (used to keep the static workflow/stub YAML in sync with the
+# Python SSOT; pinned by a drift test).
+# ---------------------------------------------------------------------------
+
+
+def render_workflow_call_secrets(names=DEFAULT_CI_SECRETS, *, indent: int = 4) -> str:
+    """Render the ``on.workflow_call.secrets:`` body for the reusable workflow.
+
+    Every secret is declared ``required: false`` — the publish job enforces
+    ``PYPI_PASSWORD`` at run time with a clear message, and the export action
+    enforces any repo-declared ``required_envvars``.
+
+    >>> print(render_workflow_call_secrets(["PYPI_PASSWORD", "OPENAI_API_KEY"]))
+        PYPI_PASSWORD:
+          required: false
+        OPENAI_API_KEY:
+          required: false
+    """
+    pad = " " * indent
+    lines = []
+    for name in names:
+        lines.append(f"{pad}{name}:")
+        lines.append(f"{pad}  required: false")
+    return "\n".join(lines)
+
+
+def render_stub_secrets_passthrough(
+    names=DEFAULT_CI_SECRETS, *, indent: int = 6
+) -> str:
+    """Render the caller stub's ``secrets:`` pass-through block.
+
+    >>> print(render_stub_secrets_passthrough(["PYPI_PASSWORD", "NPM_TOKEN"]))
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    """
+    pad = " " * indent
+    return "\n".join(f"{pad}{name}: ${{{{ secrets.{name} }}}}" for name in names)

--- a/wads/data/github_ci_uv_stub.yml
+++ b/wads/data/github_ci_uv_stub.yml
@@ -30,19 +30,19 @@ jobs:
       contents: write
       pages: write
     # Explicit pass-through (not `secrets: inherit`) because `inherit` does
-    # not reliably propagate caller-repo secrets to a reusable workflow
-    # owned by a different account (verified empirically: caller in a
-    # personal account, called in i2mint org → `${{ secrets.PYPI_PASSWORD }}`
-    # resolved to empty inside the reusable workflow despite the secret
-    # being set on the caller repo). Listing each secret here makes the
-    # propagation unambiguous regardless of caller-vs-called ownership.
-    # Missing secrets on the caller resolve to empty strings, harmless for
-    # the optional ones; PYPI_PASSWORD must be set for the publish job.
+    # not reliably propagate caller-repo secrets to a reusable workflow owned
+    # by a different account (verified empirically: personal-account caller +
+    # i2mint-org workflow → `${{ secrets.PYPI_PASSWORD }}` resolved to empty).
+    #
+    # This list is the per-repo *transport*: it should contain PYPI_PASSWORD
+    # (for publishing) plus every secret your tests/CI need. It is generated
+    # from [tool.wads.ci.env] in pyproject.toml. To add one, run
+    #   wads-secrets add VAR_NAME            # updates pyproject + this block
+    # or just append a line below. *Which* of these become job env vars (and
+    # which are required) is controlled by [tool.wads.ci.env] — passing a
+    # secret here does not by itself put it in the environment.
+    #
+    # A secret name must also be declared in the reusable workflow's superset
+    # (wads/ci_secrets.py). `wads-secrets add` warns if it is not.
     secrets:
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
-      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+#SECRETS_BLOCK#

--- a/wads/data/pyproject_toml_tpl.toml
+++ b/wads/data/pyproject_toml_tpl.toml
@@ -163,6 +163,13 @@ format = [
 # Control which environment variables are required or have defaults
 
 [tool.wads.ci.env]
+# This section decides which secrets become job environment variables in CI
+# (and which are mandatory). The reusable workflow's `export-ci-env` step reads
+# it; only the names listed here are written into the environment. Adding a name
+# here is half the job — the secret must also be *passed* by .github/workflows/
+# ci.yml (the transport list). Use `wads-secrets add NAME` to do both at once
+# (and optionally `gh secret set` the value).
+#
 # Required environment variables - CI will FAIL if these are not set in secrets
 # These must be available in GitHub Secrets for CI to run
 # Format: list of variable names
@@ -183,6 +190,13 @@ extra_envvars = []
 # Note: These are literal defaults, NOT secret values
 # Example: defaults = {"LOG_LEVEL" = "DEBUG", "TESTING" = "true", "PYTHONUNBUFFERED" = "1"}
 defaults = {}
+
+# Secret aliases - expose a GitHub secret under a DIFFERENT env-var name in CI.
+# Map: ENV_VAR_NAME = "BACKING_SECRET_NAME". Env vars not listed here are backed
+# by an identically-named secret. Example: read secrets.HF_WRITE_TOKEN but make
+# it available to tests as HF_TOKEN:
+# [tool.wads.ci.env.secret_aliases]
+# HF_TOKEN = "HF_WRITE_TOKEN"
 
 # ============================================================================
 # ✅ CODE QUALITY AND FORMATTING

--- a/wads/migration.py
+++ b/wads/migration.py
@@ -882,8 +882,10 @@ def migrate_ci_to_stub(
         >>> stub = migrate_ci_to_stub()
         >>> 'i2mint/wads/.github/workflows/uv-ci.yml@master' in stub
         True
-        >>> 'secrets: inherit' in stub
+        >>> 'PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}' in stub
         True
+        >>> '#SECRETS_BLOCK#' in stub  # placeholder is always filled
+        False
         >>> pinned = migrate_ci_to_stub(pin='@v0.1.81')
         >>> 'uv-ci.yml@v0.1.81' in pinned
         True
@@ -894,7 +896,44 @@ def migrate_ci_to_stub(
         stub = f.read()
     if pin != "@master":
         stub = stub.replace("uv-ci.yml@master", f"uv-ci.yml{pin}")
+    # Fill the per-repo transport list from the repo's [tool.wads.ci.env] when a
+    # pyproject.toml is alongside the old CI; otherwise default to publish-only.
+    secrets_block = _stub_secrets_block_for(old_ci)
+    stub = stub.replace("#SECRETS_BLOCK#", secrets_block)
     return stub
+
+
+def _stub_secrets_block_for(old_ci) -> str:
+    """Render the stub ``secrets:`` block, driven by a nearby pyproject.toml.
+
+    Looks for a ``pyproject.toml`` next to ``old_ci`` (or in its repo root) and
+    uses its ``[tool.wads.ci.env]`` to decide which secrets to transport. Falls
+    back to publish-only (``PYPI_PASSWORD``) when no config is available.
+    """
+    from wads.ci_secrets import render_stub_secrets_passthrough
+
+    pyproject = _find_pyproject_near(old_ci)
+    if pyproject is not None:
+        try:
+            from wads.ci_config import CIConfig
+
+            return CIConfig.from_file(str(pyproject)).generate_stub_secrets_block()
+        except Exception:
+            pass
+    return render_stub_secrets_passthrough(["PYPI_PASSWORD"])
+
+
+def _find_pyproject_near(old_ci) -> Path | None:
+    """Best-effort locate a pyproject.toml given a CI path like .../.github/workflows/ci.yml."""
+    if not old_ci:
+        return None
+    p = Path(old_ci)
+    # Walk up from the CI file looking for a sibling pyproject.toml.
+    for parent in [p] + list(p.parents):
+        candidate = (parent if parent.is_dir() else parent.parent) / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def main():

--- a/wads/populate.py
+++ b/wads/populate.py
@@ -1080,6 +1080,16 @@ def _add_ci_def(
             # Basic substitutions for static template
             ci_def = ci_def.replace("#PROJECT_NAME#", name)
 
+        # The SSOT stub carries a #SECRETS_BLOCK# placeholder (the per-repo
+        # transport list). The dynamic path fills it from [tool.wads.ci.env];
+        # otherwise fall back to the publish-only default so the stub is valid.
+        if "#SECRETS_BLOCK#" in ci_def:
+            from wads.ci_secrets import render_stub_secrets_passthrough
+
+            ci_def = ci_def.replace(
+                "#SECRETS_BLOCK#", render_stub_secrets_passthrough(["PYPI_PASSWORD"])
+            )
+
         # Common substitutions for all templates
         hostname = urlparse(root_url).netloc
         ci_def = ci_def.replace("#GITLAB_HOSTNAME#", hostname)

--- a/wads/scripts/export_ci_env.py
+++ b/wads/scripts/export_ci_env.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Export the pyproject-declared CI environment to ``$GITHUB_ENV``.
+
+This is the run-time half of wads' two-layer secret model (see
+:mod:`wads.ci_secrets`). The reusable workflow declares a static *superset* of
+secrets (transport); this script decides which of them actually become job
+environment variables, driven entirely by ``[tool.wads.ci.env]`` in the
+consumer's ``pyproject.toml`` (read via the ``read-ci-config`` action):
+
+* ``defaults``  — literal ``KEY=value`` pairs, always written.
+* ``required_envvars`` — must resolve to a non-empty secret, else CI **fails**
+  with a precise message.
+* ``test_envvars`` — exported if set; a **warning** is emitted if missing.
+* ``extra_envvars`` — exported if set; silent if missing.
+* ``secret_aliases`` — map ``ENV_VAR -> SECRET_NAME`` for the (rare) case where
+  the env var the code reads differs from the GitHub secret name.
+
+The full ``secrets`` context is handed in as JSON via ``toJSON(secrets)`` so this
+logic needs **no per-secret enumeration** — only the workflow's static
+``on.workflow_call.secrets`` block enumerates (and that is generated from
+:data:`wads.ci_secrets.DEFAULT_CI_SECRETS`).
+
+Secret *values* are never printed; only names appear in the summary. Values are
+GitHub-registered secrets and are masked in logs regardless.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _gh_env_assignment(name: str, value: str) -> str:
+    """Return a ``$GITHUB_ENV`` assignment line(s) for ``name=value``.
+
+    Single-line values use ``NAME=value``; multi-line values (e.g. an
+    ``SSH_PRIVATE_KEY``) use the documented heredoc form with a delimiter that
+    is guaranteed not to occur inside the value.
+
+    >>> _gh_env_assignment("FOO", "bar")
+    'FOO=bar'
+    >>> print(_gh_env_assignment("KEY", "line1\\nline2"))
+    KEY<<__WADS_EOF__
+    line1
+    line2
+    __WADS_EOF__
+    """
+    if "\n" not in value and "\r" not in value:
+        return f"{name}={value}"
+    # Pick a delimiter not present in the value.
+    delimiter = "__WADS_EOF__"
+    while delimiter in value:
+        delimiter += "_"
+    return f"{name}<<{delimiter}\n{value}\n{delimiter}"
+
+
+def export_ci_env(
+    *,
+    required=(),
+    test=(),
+    extra=(),
+    defaults=None,
+    aliases=None,
+    secrets=None,
+    warn=lambda msg: print(msg, file=sys.stderr),
+):
+    """Compute the env assignments to write, plus any missing-required errors.
+
+    Pure function (no I/O) so it can be unit-tested without GitHub. Returns
+    ``(assignments, exported, missing_required, missing_test)`` where
+    ``assignments`` is an ordered list of ``$GITHUB_ENV`` lines.
+
+    >>> a, exported, missing_req, missing_test = export_ci_env(
+    ...     required=["OPENAI_API_KEY"],
+    ...     test=["TAVILY_API_KEY"],
+    ...     extra=["UNSET_THING"],
+    ...     defaults={"LOG_LEVEL": "DEBUG"},
+    ...     secrets={"OPENAI_API_KEY": "sk-xxx", "TAVILY_API_KEY": ""},
+    ... )
+    >>> exported
+    ['LOG_LEVEL', 'OPENAI_API_KEY']
+    >>> missing_req
+    []
+    >>> missing_test
+    ['TAVILY_API_KEY']
+
+    A required var with no backing secret is reported (caller should fail CI):
+
+    >>> _, _, missing_req, _ = export_ci_env(
+    ...     required=["PYPI_PASSWORD"], secrets={})
+    >>> missing_req
+    [('PYPI_PASSWORD', 'PYPI_PASSWORD')]
+
+    Aliases let an env var read a differently-named secret:
+
+    >>> a, exported, _, _ = export_ci_env(
+    ...     test=["HF_TOKEN"],
+    ...     aliases={"HF_TOKEN": "HF_WRITE_TOKEN"},
+    ...     secrets={"HF_WRITE_TOKEN": "hf_xxx"})
+    >>> exported
+    ['HF_TOKEN']
+    >>> a
+    ['HF_TOKEN=hf_xxx']
+    """
+    defaults = defaults or {}
+    aliases = aliases or {}
+    secrets = secrets or {}
+
+    assignments = []
+    exported = []
+    missing_required = []
+    missing_test = []
+
+    # Literal defaults first, so a secret-backed var of the same name wins.
+    for key, value in defaults.items():
+        assignments.append(_gh_env_assignment(str(key), str(value)))
+        exported.append(str(key))
+
+    def _resolve(var_name):
+        secret_name = aliases.get(var_name, var_name)
+        return secret_name, secrets.get(secret_name) or ""
+
+    seen = set(exported)
+    for var_name in required:
+        secret_name, value = _resolve(var_name)
+        if not value:
+            missing_required.append((var_name, secret_name))
+            continue
+        if var_name not in seen:
+            assignments.append(_gh_env_assignment(var_name, value))
+            exported.append(var_name)
+            seen.add(var_name)
+
+    for var_name in test:
+        secret_name, value = _resolve(var_name)
+        if not value:
+            missing_test.append(var_name)
+            continue
+        if var_name not in seen:
+            assignments.append(_gh_env_assignment(var_name, value))
+            exported.append(var_name)
+            seen.add(var_name)
+
+    for var_name in extra:
+        _, value = _resolve(var_name)
+        if value and var_name not in seen:
+            assignments.append(_gh_env_assignment(var_name, value))
+            exported.append(var_name)
+            seen.add(var_name)
+
+    for var_name in missing_test:
+        warn(
+            f"::warning::[tool.wads.ci.env].test_envvars lists {var_name!r} but "
+            f"its backing secret is not set on this repo; tests needing it may be "
+            f"skipped or fail."
+        )
+
+    return assignments, exported, missing_required, missing_test
+
+
+def _load_json_env(name: str, default):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        print(f"[ERROR] {name} is not valid JSON: {raw!r}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    """Read inputs from env, write assignments to ``$GITHUB_ENV``, fail if required missing."""
+    required = _load_json_env("WADS_ENV_REQUIRED", [])
+    test = _load_json_env("WADS_ENV_TEST", [])
+    extra = _load_json_env("WADS_ENV_EXTRA", [])
+    defaults = _load_json_env("WADS_ENV_DEFAULTS", {})
+    aliases = _load_json_env("WADS_ENV_ALIASES", {})
+    secrets = _load_json_env("WADS_SECRETS_JSON", {})
+
+    assignments, exported, missing_required, _ = export_ci_env(
+        required=required,
+        test=test,
+        extra=extra,
+        defaults=defaults,
+        aliases=aliases,
+        secrets=secrets,
+    )
+
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a") as f:
+            for line in assignments:
+                f.write(line + "\n")
+    else:
+        print("Warning: GITHUB_ENV not set; not writing assignments", file=sys.stderr)
+
+    if exported:
+        print(f"[OK] Exported CI env vars: {', '.join(exported)}")
+    else:
+        print("[OK] No CI env vars configured to export")
+
+    if missing_required:
+        details = "\n".join(
+            f"  - env var {var!r} (backed by secret {sec!r}) is required by "
+            f"[tool.wads.ci.env].required_envvars but the secret is not set"
+            for var, sec in missing_required
+        )
+        print(
+            "[ERROR] Required CI secrets are missing:\n"
+            f"{details}\n"
+            "Set them on the repo (e.g. `wads-secrets add NAME` or "
+            "`gh secret set NAME`), or move them out of required_envvars.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wads/scripts/read_ci_config.py
+++ b/wads/scripts/read_ci_config.py
@@ -109,6 +109,15 @@ def read_and_export_ci_config(pyproject_path: str | Path = ".") -> int:
         _set_output("skip-ci-marker", config.publish_skip_ci_marker)
         _set_output("publish-marker", config.publish_marker)
 
+        # Environment-variable policy (consumed by the export-ci-env action).
+        # These decide which secrets are written into the job environment and
+        # which are mandatory; the transport superset lives in the workflow YAML.
+        _set_output("env-required", config.env_vars_required)
+        _set_output("env-test", config.env_vars_test)
+        _set_output("env-extra", config.env_vars_extra)
+        _set_output("env-defaults", config.env_vars_defaults)
+        _set_output("env-aliases", config.env_secret_aliases)
+
         # Print summary
         print("[OK] CI configuration loaded successfully")
         print(f"   Project: {config.project_name}")

--- a/wads/secrets_cli.py
+++ b/wads/secrets_cli.py
@@ -1,0 +1,377 @@
+"""``wads-secrets`` — manage the CI secrets/env vars of a wads-managed repo.
+
+A secret becomes usable in CI through two coordinated edits (see
+:mod:`wads.ci_secrets` for the model):
+
+1. **pyproject** ``[tool.wads.ci.env]`` — declares the env var (and whether it
+   is required), so the reusable workflow exports it into the job environment.
+2. **stub transport** — the repo's ``ci.yml`` must *pass* the backing secret to
+   the reusable workflow (cross-owner ``secrets: inherit`` is unreliable).
+
+``wads-secrets add`` performs both edits in one step, and can also set the
+secret's value on GitHub via ``gh`` — so a single command takes a secret from
+"not configured" to "available in CI".
+
+Examples::
+
+    wads-secrets add OPENAI_API_KEY                 # var == secret name
+    wads-secrets add HF_TOKEN HF_WRITE_TOKEN         # env var <- aliased secret
+    wads-secrets add DB_URL --kind required          # fail CI if unset
+    wads-secrets add OPENAI_API_KEY --no-github      # edit files only
+    wads-secrets list                                # show configured env vars
+
+Names are forced to ``UPPER_SNAKE`` and value-looking inputs are rejected, so
+you can't accidentally commit a secret *value* as a name.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from wads.ci_secrets import (
+    DEFAULT_CI_SECRETS,
+    InvalidSecretName,
+    normalize_secret_name,
+)
+
+_KINDS = {
+    "required": "required_envvars",
+    "test": "test_envvars",
+    "extra": "extra_envvars",
+}
+
+
+def _err(msg: str):
+    print(f"error: {msg}", file=sys.stderr)
+
+
+def _repo_from_git(path: str = ".") -> "str | None":
+    """Return ``org/repo`` from the git ``origin`` remote of ``path``, or None.
+
+    >>> _repo_from_git("/does/not/exist") is None
+    True
+    """
+    try:
+        url = subprocess.check_output(
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    # git@github.com:org/repo.git  or  https://github.com/org/repo(.git)
+    m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?/?$", url)
+    return m.group(1) if m else None
+
+
+def _load_toml_doc(pyproject_path: Path):
+    try:
+        import tomlkit
+    except ImportError:
+        raise SystemExit(
+            "wads-secrets needs `tomlkit` to edit pyproject.toml. "
+            "Install it with `pip install tomlkit` or `pip install wads[create]`."
+        )
+    return tomlkit, tomlkit.parse(pyproject_path.read_text())
+
+
+def _ci_env_table(tomlkit, doc):
+    """Get-or-create the ``[tool.wads.ci.env]`` table in ``doc``."""
+    tool = doc.setdefault("tool", tomlkit.table())
+    wads = tool.setdefault("wads", tomlkit.table())
+    ci = wads.setdefault("ci", tomlkit.table())
+    env = ci.setdefault("env", tomlkit.table())
+    return env
+
+
+def _existing_bucket(env, var_name: str) -> "str | None":
+    """Return the bucket name ('required_envvars'/...) where ``var_name`` already lives."""
+    for bucket in _KINDS.values():
+        if var_name in list(env.get(bucket, []) or []):
+            return bucket
+    return None
+
+
+def add_env_var_to_pyproject(pyproject_path, var_name, secret_name, *, kind="extra"):
+    """Add ``var_name`` to ``[tool.wads.ci.env]``; record alias if names differ.
+
+    Returns ``(changed, existing_bucket)``. If the var is already declared,
+    makes no change and returns ``(False, <bucket>)``.
+    """
+    pyproject_path = Path(pyproject_path)
+    bucket = _KINDS[kind]
+    tomlkit, doc = _load_toml_doc(pyproject_path)
+    env = _ci_env_table(tomlkit, doc)
+
+    already = _existing_bucket(env, var_name)
+    if already:
+        return False, already
+
+    arr = env.get(bucket)
+    if arr is None:
+        arr = tomlkit.array()
+        env[bucket] = arr
+    arr.append(var_name)
+
+    if secret_name != var_name:
+        aliases = env.get("secret_aliases")
+        if aliases is None:
+            aliases = tomlkit.table()
+            env["secret_aliases"] = aliases
+        aliases[var_name] = secret_name
+
+    pyproject_path.write_text(tomlkit.dumps(doc))
+    return True, None
+
+
+def add_secret_to_stub(ci_file, secret_name):
+    """Ensure the stub ``ci.yml`` passes ``secret_name`` to the reusable workflow.
+
+    Returns ``(changed, reason)``. ``reason`` explains no-ops (already present,
+    not a stub, file missing).
+    """
+    ci_file = Path(ci_file)
+    if not ci_file.is_file():
+        return False, "no ci.yml found (skipped transport edit)"
+    text = ci_file.read_text()
+    if "uv-ci.yml" not in text:
+        return False, (
+            "ci.yml is not the wads reusable-workflow stub (inline workflow?); "
+            "transport not edited — env is driven by [tool.wads.ci.env]"
+        )
+    if re.search(rf"secrets\.{re.escape(secret_name)}\b", text):
+        return False, "already passed in ci.yml"
+
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)secrets:\s*$", line)
+        if m:
+            indent = m.group(1) + "  "
+            newline = (
+                "" if line.endswith("\n") else "\n"
+            )  # ensure secrets: line terminated
+            entry = f"{indent}{secret_name}: ${{{{ secrets.{secret_name} }}}}\n"
+            lines[i] = line + newline
+            lines.insert(i + 1, entry)
+            ci_file.write_text("".join(lines))
+            return True, "added to ci.yml transport"
+    return False, "could not locate a `secrets:` block in ci.yml"
+
+
+def _gh_available() -> bool:
+    try:
+        subprocess.check_output(["gh", "--version"], stderr=subprocess.DEVNULL)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def set_github_secret(repo, secret_name, value) -> bool:
+    """Set ``secret_name`` on ``repo`` via ``gh secret set``. Returns success."""
+    try:
+        subprocess.run(
+            ["gh", "secret", "set", secret_name, "--repo", repo, "--body", value],
+            check=True,
+        )
+        return True
+    except subprocess.CalledProcessError as e:
+        _err(f"gh secret set failed: {e}")
+        return False
+
+
+def add(
+    var_name,
+    secret_name=None,
+    *,
+    repo=None,
+    kind="extra",
+    value=None,
+    github=True,
+    pyproject="pyproject.toml",
+    ci_file=".github/workflows/ci.yml",
+):
+    """Configure a CI secret: declare it in pyproject, pass it in ci.yml, set its value.
+
+    :param var_name: env-var name your code reads (forced to UPPER_SNAKE).
+    :param secret_name: GitHub secret backing it (default: same as var_name).
+    :param repo: ``org/repo`` to set the secret on (default: git origin here).
+    :param kind: ``extra`` (default), ``test``, or ``required``.
+    :param value: secret value to push to GitHub (default: ``$VAR_NAME`` in env).
+    :param github: also set the value on GitHub via ``gh`` (default True).
+    """
+    try:
+        var_name = normalize_secret_name(var_name)
+        secret_name = normalize_secret_name(secret_name) if secret_name else var_name
+    except InvalidSecretName as e:
+        _err(str(e))
+        return 1
+    if kind not in _KINDS:
+        _err(f"--kind must be one of {sorted(_KINDS)}, got {kind!r}")
+        return 1
+
+    changed, existing = add_env_var_to_pyproject(
+        pyproject, var_name, secret_name, kind=kind
+    )
+    if not changed and existing:
+        print(
+            f"'{var_name}' is already configured in [tool.wads.ci.env].{existing}; "
+            "nothing to add."
+        )
+        return 0
+    print(f"✓ pyproject: added {var_name!r} to [tool.wads.ci.env].{_KINDS[kind]}")
+    if secret_name != var_name:
+        print(f"  ↳ aliased to secret {secret_name!r}")
+
+    stub_changed, reason = add_secret_to_stub(ci_file, secret_name)
+    print(f"{'✓' if stub_changed else '·'} transport: {reason}")
+
+    if secret_name not in DEFAULT_CI_SECRETS:
+        print(
+            f"⚠ {secret_name!r} is not in the wads secret superset "
+            f"(wads/ci_secrets.py). The reusable workflow will reject an "
+            f"undeclared secret. Add it to DEFAULT_CI_SECRETS via a wads PR, or "
+            f"use the inline-workflow escape valve."
+        )
+
+    if github:
+        _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file)
+    return 0
+
+
+def _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file):
+    if not _gh_available():
+        print(
+            f"· github: `gh` not found; set it manually:\n"
+            f"    gh secret set {secret_name} --repo <org/repo>"
+        )
+        return
+    repo = repo or _repo_from_git(
+        Path(ci_file).resolve().parents[2] if Path(ci_file).is_file() else "."
+    )
+    if not repo:
+        print(
+            f"· github: could not detect repo (no git origin); set it manually:\n"
+            f"    gh secret set {secret_name} --repo <org/repo>"
+        )
+        return
+    if value is None:
+        value = os.environ.get(var_name) or os.environ.get(secret_name)
+    if not value:
+        print(
+            f"· github: no value for {secret_name!r} (pass --value or export "
+            f"${var_name}); set it later with:\n"
+            f"    gh secret set {secret_name} --repo {repo}"
+        )
+        return
+    if set_github_secret(repo, secret_name, value):
+        print(f"✓ github: set secret {secret_name!r} on {repo}")
+
+
+def list_(pyproject="pyproject.toml"):
+    """List the env vars configured in ``[tool.wads.ci.env]``."""
+    from wads.ci_config import CIConfig
+
+    config = CIConfig.from_file(pyproject)
+    aliases = config.env_secret_aliases
+    buckets = {
+        "required": config.env_vars_required,
+        "test": config.env_vars_test,
+        "extra": config.env_vars_extra,
+    }
+    any_var = False
+    for kind, names in buckets.items():
+        for name in names:
+            any_var = True
+            secret = aliases.get(name, name)
+            suffix = f"  (secret: {secret})" if secret != name else ""
+            print(f"  [{kind}] {name}{suffix}")
+    if config.env_vars_defaults:
+        for k, v in config.env_vars_defaults.items():
+            print(f"  [default] {k} = {v}")
+    if not any_var and not config.env_vars_defaults:
+        print("No CI env vars configured in [tool.wads.ci.env].")
+    return 0
+
+
+def superset():
+    """Print the wads secret superset (names a stub may pass)."""
+    for name in DEFAULT_CI_SECRETS:
+        print(name)
+    return 0
+
+
+def main(argv=None):
+    """``wads-secrets`` CLI entry point (argparse-based)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="wads-secrets",
+        description="Manage the CI secrets / env vars of a wads-managed repo.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_add = sub.add_parser(
+        "add", help="declare a CI secret + pass it in ci.yml + set its value"
+    )
+    p_add.add_argument(
+        "var_name", help="env-var name your code reads (forced UPPER_SNAKE)"
+    )
+    p_add.add_argument(
+        "secret_name",
+        nargs="?",
+        default=None,
+        help="GitHub secret backing it (default: same as VAR_NAME)",
+    )
+    p_add.add_argument(
+        "--repo",
+        default=None,
+        help="org/repo to set the secret on (default: git origin)",
+    )
+    p_add.add_argument(
+        "--kind",
+        choices=sorted(_KINDS),
+        default="extra",
+        help="env-var bucket (default: extra)",
+    )
+    p_add.add_argument(
+        "--value",
+        default=None,
+        help="secret value to push to GitHub (default: $VAR_NAME)",
+    )
+    p_add.add_argument(
+        "--no-github",
+        dest="github",
+        action="store_false",
+        help="edit files only; don't call gh",
+    )
+    p_add.add_argument("--pyproject", default="pyproject.toml")
+    p_add.add_argument("--ci-file", dest="ci_file", default=".github/workflows/ci.yml")
+
+    p_list = sub.add_parser("list", help="list configured CI env vars")
+    p_list.add_argument("--pyproject", default="pyproject.toml")
+
+    sub.add_parser("superset", help="print the wads secret superset")
+
+    args = parser.parse_args(argv)
+    if args.command == "add":
+        return add(
+            args.var_name,
+            args.secret_name,
+            repo=args.repo,
+            kind=args.kind,
+            value=args.value,
+            github=args.github,
+            pyproject=args.pyproject,
+            ci_file=args.ci_file,
+        )
+    if args.command == "list":
+        return list_(pyproject=args.pyproject)
+    if args.command == "superset":
+        return superset()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
+++ b/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
@@ -30,19 +30,19 @@ jobs:
       contents: write
       pages: write
     # Explicit pass-through (not `secrets: inherit`) because `inherit` does
-    # not reliably propagate caller-repo secrets to a reusable workflow
-    # owned by a different account (verified empirically: caller in a
-    # personal account, called in i2mint org → `${{ secrets.PYPI_PASSWORD }}`
-    # resolved to empty inside the reusable workflow despite the secret
-    # being set on the caller repo). Listing each secret here makes the
-    # propagation unambiguous regardless of caller-vs-called ownership.
-    # Missing secrets on the caller resolve to empty strings, harmless for
-    # the optional ones; PYPI_PASSWORD must be set for the publish job.
+    # not reliably propagate caller-repo secrets to a reusable workflow owned
+    # by a different account (verified empirically: personal-account caller +
+    # i2mint-org workflow → `${{ secrets.PYPI_PASSWORD }}` resolved to empty).
+    #
+    # This list is the per-repo *transport*: it should contain PYPI_PASSWORD
+    # (for publishing) plus every secret your tests/CI need. It is generated
+    # from [tool.wads.ci.env] in pyproject.toml. To add one, run
+    #   wads-secrets add VAR_NAME            # updates pyproject + this block
+    # or just append a line below. *Which* of these become job env vars (and
+    # which are required) is controlled by [tool.wads.ci.env] — passing a
+    # secret here does not by itself put it in the environment.
+    #
+    # A secret name must also be declared in the reusable workflow's superset
+    # (wads/ci_secrets.py). `wads-secrets add` warns if it is not.
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
-      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}

--- a/wads/tests/test_ci_secrets.py
+++ b/wads/tests/test_ci_secrets.py
@@ -1,0 +1,85 @@
+"""Tests for the CI secret superset SSOT and its YAML renderings.
+
+The canonical list lives in :mod:`wads.ci_secrets`. GitHub requires the
+reusable workflow's ``on.workflow_call.secrets`` block to be static literal
+YAML, so a *copy* of the names lives in ``.github/workflows/uv-ci.yml``. These
+tests pin that copy to the Python SSOT so the two can never drift.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from wads.ci_secrets import (
+    DEFAULT_CI_SECRETS,
+    InvalidSecretName,
+    is_valid_secret_name,
+    normalize_secret_name,
+    render_stub_secrets_passthrough,
+    render_workflow_call_secrets,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UV_CI = REPO_ROOT / ".github" / "workflows" / "uv-ci.yml"
+
+
+def test_superset_is_deduped_and_nonempty():
+    assert len(DEFAULT_CI_SECRETS) == len(set(DEFAULT_CI_SECRETS))
+    assert "PYPI_PASSWORD" in DEFAULT_CI_SECRETS
+    assert len(DEFAULT_CI_SECRETS) > 20
+
+
+def test_every_superset_name_is_valid():
+    for name in DEFAULT_CI_SECRETS:
+        assert is_valid_secret_name(name), name
+
+
+def test_normalize_secret_name():
+    assert normalize_secret_name("my-api.key") == "MY_API_KEY"
+    assert normalize_secret_name("  hf token ") == "HF_TOKEN"
+    assert normalize_secret_name("OPENAI_API_KEY") == "OPENAI_API_KEY"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["sk-proj-abc/123+x=", "GITHUB_TOKEN", "", "   ", "a" * 100],
+)
+def test_normalize_rejects_value_like_and_reserved(bad):
+    with pytest.raises(InvalidSecretName):
+        normalize_secret_name(bad)
+
+
+def _secrets_from_workflow(path: Path):
+    """Return the declared ``on.workflow_call.secrets`` names, in file order."""
+    data = yaml.safe_load(path.read_text())
+    # PyYAML parses the bare key `on:` as the boolean True.
+    on = data.get("on", data.get(True))
+    return list(on["workflow_call"]["secrets"].keys())
+
+
+def test_uv_ci_secrets_match_ssot_exactly():
+    """The reusable workflow's secret superset must equal DEFAULT_CI_SECRETS.
+
+    If this fails, you edited one side only. Regenerate the YAML block from
+    wads.ci_secrets.render_workflow_call_secrets() (or update DEFAULT_CI_SECRETS).
+    """
+    declared = _secrets_from_workflow(UV_CI)
+    assert declared == list(DEFAULT_CI_SECRETS)
+
+
+def test_rendered_workflow_block_roundtrips():
+    """The rendered block parses to exactly the SSOT names."""
+    block = render_workflow_call_secrets(indent=6)
+    fake = "on:\n  workflow_call:\n    secrets:\n" + block + "\n"
+    parsed = yaml.safe_load(fake)
+    on = parsed.get("on", parsed.get(True))
+    assert list(on["workflow_call"]["secrets"].keys()) == list(DEFAULT_CI_SECRETS)
+
+
+def test_stub_passthrough_render():
+    out = render_stub_secrets_passthrough(["PYPI_PASSWORD", "NPM_TOKEN"])
+    assert out == (
+        "      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}\n"
+        "      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}"
+    )

--- a/wads/tests/test_export_ci_env.py
+++ b/wads/tests/test_export_ci_env.py
@@ -1,0 +1,61 @@
+"""Tests for the run-time env-export logic (``wads.scripts.export_ci_env``)."""
+
+from wads.scripts.export_ci_env import _gh_env_assignment, export_ci_env
+
+
+def test_exports_only_configured_and_set():
+    assignments, exported, missing_req, missing_test = export_ci_env(
+        required=["OPENAI_API_KEY"],
+        test=["TAVILY_API_KEY"],
+        extra=["UNSET_THING"],
+        defaults={"LOG_LEVEL": "DEBUG"},
+        secrets={"OPENAI_API_KEY": "sk-x", "TAVILY_API_KEY": "", "OTHER": "y"},
+        warn=lambda m: None,
+    )
+    assert exported == ["LOG_LEVEL", "OPENAI_API_KEY"]
+    assert "OTHER" not in exported  # passed but not declared -> not exported
+    assert missing_req == []
+    assert missing_test == ["TAVILY_API_KEY"]
+    assert "LOG_LEVEL=DEBUG" in assignments
+    assert "OPENAI_API_KEY=sk-x" in assignments
+
+
+def test_required_missing_is_reported():
+    _, _, missing_req, _ = export_ci_env(required=["PYPI_PASSWORD"], secrets={})
+    assert missing_req == [("PYPI_PASSWORD", "PYPI_PASSWORD")]
+
+
+def test_alias_resolution():
+    assignments, exported, _, _ = export_ci_env(
+        test=["HF_TOKEN"],
+        aliases={"HF_TOKEN": "HF_WRITE_TOKEN"},
+        secrets={"HF_WRITE_TOKEN": "hf_x"},
+        warn=lambda m: None,
+    )
+    assert exported == ["HF_TOKEN"]
+    assert assignments == ["HF_TOKEN=hf_x"]
+
+
+def test_secret_overrides_default_of_same_name():
+    assignments, exported, _, _ = export_ci_env(
+        extra=["TOKEN"],
+        defaults={"TOKEN": "literal"},
+        secrets={"TOKEN": "from-secret"},
+        warn=lambda m: None,
+    )
+    # default written first, secret-backed var of same name skipped (already seen),
+    # so the literal default stands — defaults are authoritative when both exist.
+    assert exported == ["TOKEN"]
+    assert assignments == ["TOKEN=literal"]
+
+
+def test_multiline_value_uses_heredoc():
+    out = _gh_env_assignment("SSH_PRIVATE_KEY", "-----BEGIN-----\nabc\n-----END-----")
+    assert out.startswith("SSH_PRIVATE_KEY<<")
+    delim = out.splitlines()[0].split("<<", 1)[1]
+    assert out.rstrip().endswith(delim)
+    assert delim not in "-----BEGIN-----\nabc\n-----END-----"
+
+
+def test_single_line_value_plain():
+    assert _gh_env_assignment("A", "b") == "A=b"

--- a/wads/tests/test_secrets_cli.py
+++ b/wads/tests/test_secrets_cli.py
@@ -1,0 +1,97 @@
+"""Tests for the ``wads-secrets`` CLI helpers (file edits, no network)."""
+
+import pytest
+
+from wads.migration import migrate_ci_to_stub
+from wads.secrets_cli import (
+    add_env_var_to_pyproject,
+    add_secret_to_stub,
+    list_,
+    _repo_from_git,
+)
+
+PYPROJECT = """\
+[project]
+name = "demo"
+
+[tool.wads.ci.env]
+required_envvars = []
+test_envvars = []
+extra_envvars = []
+defaults = {}
+"""
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(PYPROJECT)
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text(migrate_ci_to_stub())
+    return tmp_path
+
+
+def test_add_env_var_and_alias(repo):
+    pp = repo / "pyproject.toml"
+    changed, existing = add_env_var_to_pyproject(
+        pp, "HF_TOKEN", "HF_WRITE_TOKEN", kind="required"
+    )
+    assert changed and existing is None
+    text = pp.read_text()
+    assert 'required_envvars = ["HF_TOKEN"]' in text
+    assert "[tool.wads.ci.env.secret_aliases]" in text
+    assert 'HF_TOKEN = "HF_WRITE_TOKEN"' in text
+
+
+def test_add_env_var_idempotent(repo):
+    pp = repo / "pyproject.toml"
+    add_env_var_to_pyproject(pp, "OPENAI_API_KEY", "OPENAI_API_KEY", kind="extra")
+    changed, existing = add_env_var_to_pyproject(
+        pp, "OPENAI_API_KEY", "OPENAI_API_KEY", kind="test"
+    )
+    assert not changed
+    assert existing == "extra_envvars"
+
+
+def test_add_secret_to_stub_inserts_once(repo):
+    ci = repo / ".github" / "workflows" / "ci.yml"
+    changed, _ = add_secret_to_stub(ci, "OPENAI_API_KEY")
+    assert changed
+    assert "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}" in ci.read_text()
+    # second time is a no-op
+    changed2, reason = add_secret_to_stub(ci, "OPENAI_API_KEY")
+    assert not changed2 and "already" in reason
+    assert ci.read_text().count("secrets.OPENAI_API_KEY") == 1
+
+
+def test_add_secret_to_stub_detects_non_stub(tmp_path):
+    inline = tmp_path / "ci.yml"
+    inline.write_text("name: CI\non: [push]\njobs: {}\n")
+    changed, reason = add_secret_to_stub(inline, "FOO")
+    assert not changed
+    assert "not the wads reusable-workflow stub" in reason
+
+
+def test_list_reports_configured(repo, capsys):
+    pp = repo / "pyproject.toml"
+    add_env_var_to_pyproject(pp, "HF_TOKEN", "HF_WRITE_TOKEN", kind="required")
+    list_(pyproject=str(pp))
+    out = capsys.readouterr().out
+    assert "HF_TOKEN" in out and "HF_WRITE_TOKEN" in out
+
+
+def test_repo_from_git_parses_urls(tmp_path, monkeypatch):
+    import wads.secrets_cli as m
+
+    monkeypatch.setattr(
+        m.subprocess,
+        "check_output",
+        lambda *a, **k: "git@github.com:org/repo.git\n",
+    )
+    assert m._repo_from_git(".") == "org/repo"
+    monkeypatch.setattr(
+        m.subprocess,
+        "check_output",
+        lambda *a, **k: "https://github.com/org/repo\n",
+    )
+    assert m._repo_from_git(".") == "org/repo"


### PR DESCRIPTION
Closes #45.

Makes CI secrets/env-vars **driven by `pyproject.toml`** again, after the SSOT reusable-workflow move (#28) froze them into a hardcoded curated list in `uv-ci.yml`. Fixes both symptoms: **over-assignment** (every repo got all curated vars) and **under-coverage** (couldn't add a needed secret without a wads PR).

### Design — two decoupled layers (see `wads/ci_secrets.py` docstring)

GitHub forces a reusable workflow's secret *interface* to be static YAML, and `secrets: inherit` is unreliable cross-owner — so:

1. **Transport** — `uv-ci.yml`'s `on.workflow_call.secrets` declares a generous **superset** (the universe of passable names), generated from the new `wads.ci_secrets.DEFAULT_CI_SECRETS` SSOT and **pinned by a drift test**. Each repo's stub passes only a *small subset*: `PYPI_PASSWORD` + whatever its `[tool.wads.ci.env]` declares (rendered into the stub's `#SECRETS_BLOCK#` placeholder at populate/migrate time). So the per-repo `ci.yml` stays tiny.
2. **Env-assignment** — the new `export-ci-env` action (`wads/scripts/export_ci_env.py`) writes **exactly** the pyproject-declared vars to `$GITHUB_ENV` (via `toJSON(secrets)`), supports `secret_aliases` (ENV_VAR≠SECRET), and **fails fast** on a missing required secret. `read-ci-config` now emits `env-required/-test/-extra/-defaults/-aliases`.

A passed-but-undeclared secret is **never** written to the environment → no over-assignment. A declared-required secret that's unset → loud CI failure naming the secret → no silent under-coverage.

### `wads-secrets` CLI

`wads-secrets add VAR_NAME [SECRET_NAME]` declares the var in `[tool.wads.ci.env]` **and** adds the transport line to `ci.yml` in one step, and can `gh secret set` the value (`--value`, else `$VAR_NAME`). Forces `UPPER_SNAKE`, rejects value-looking input, autodetects the repo from git. Also `list` and `superset`. Idempotent.

### The superset

Adopts the maintainer's 27-name working set (normalized) + upstream-canonical aliases (e.g. `ELEVENLABS_API_KEY`, `APCA_API_KEY_ID`, `SPOTIPY_CLIENT_ID`) + ~30 widely-used names (publishing, LLM/AI, cloud, messaging, storage). Over-listing is harmless and one-line-widenable. Full analysis in the issue.

### Escape valves

- Name outside the superset → one-line PR to `wads.ci_secrets` (benefits everyone) or the inline-workflow template (`github_ci_uv.yml`, already env-parametrized). The CLI warns when a name is beyond the superset.

### Tests / compat

- New: `test_ci_secrets.py` (SSOT + YAML drift-pin), `test_export_ci_env.py`, `test_secrets_cli.py`.
- Updated the `python_lib` `ci.yml` golden (stub now publish-only by default) and fixed the stale `secrets: inherit` doctest in `migration.py`.
- `tomlkit` added to the `create` extra (lazy-imported; light install unaffected).
- Full suite: **289 passed**.
