### PR TITLE
Gate publish on validation + fix export-ci-env manifest crash (follow-up to #45)

### DIFF
--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -368,15 +368,18 @@ jobs:
   # without these outputs is installed by read-ci-config, publishing is skipped
   # rather than run unintentionally.
   #
-  # Per repo policy, test failures do NOT block publication. The `if:` uses
-  # `!cancelled() && needs.setup.result == 'success'` so this job runs even
-  # when `validation` fails, while still requiring `setup` to have succeeded
-  # (publish consumes its outputs) and respecting workflow cancellation.
+  # VALIDATION GATES PUBLISH. The `if:` contains no status function (no
+  # `always()`/`!cancelled()`), so GitHub applies the implicit `success()`:
+  # this job runs only when ALL of its `needs` succeed — i.e. both `setup` and
+  # the Linux `validation` matrix (python 3.10 AND 3.12). A failing test on
+  # Linux therefore blocks publication. Windows is a SEPARATE job
+  # (`windows-validation`, not in `needs` and `continue-on-error`), so it stays
+  # optional and never blocks publishing.
   publish:
     name: Publish
     permissions:
       contents: write
-    if: "!cancelled() && needs.setup.result == 'success' && !contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
+    if: "!contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
     needs: [setup, validation]
     runs-on: ubuntu-latest
 

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -32,7 +32,10 @@ inputs:
     required: false
     default: '{}'
   secrets-json:
-    description: 'The secrets context as JSON. Pass `${{ toJSON(secrets) }}`.'
+    # NOTE: do not write a GitHub expression literally here — the manifest
+    # loader evaluates expressions even inside description strings, and the
+    # `secrets` context is not available in a composite action manifest.
+    description: 'The secrets context serialized as JSON by the caller (toJSON of the secrets context).'
     required: true
 
 runs:

--- a/wads/tests/test_workflow_gates.py
+++ b/wads/tests/test_workflow_gates.py
@@ -1,0 +1,61 @@
+"""Regression guards for two CI wiring bugs (see issue #45 follow-up).
+
+1. A GitHub *expression* (``${{ ... }}``) written literally inside an action
+   manifest's input ``description``/``default`` is evaluated at manifest-load
+   time. Referencing the ``secrets`` context there crashes the whole action
+   ("Unrecognized named-value: 'secrets'"), which took down the validation job.
+
+2. The reusable workflow's ``publish`` job must be gated on the Linux
+   ``validation`` matrix — a failing test must block publication. This pins
+   that the gate has no status-function escape hatch (``!cancelled()`` /
+   ``always()``) and that ``validation`` is a dependency.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTIONS_DIR = REPO_ROOT / "actions"
+UV_CI = REPO_ROOT / ".github" / "workflows" / "uv-ci.yml"
+
+
+def test_no_action_input_embeds_github_expression():
+    """No action.yml input description/default may contain a `${{ }}` expression."""
+    offenders = []
+    for action_yml in ACTIONS_DIR.glob("*/action.yml"):
+        data = yaml.safe_load(action_yml.read_text())
+        for name, spec in (data.get("inputs") or {}).items():
+            for field in ("description", "default"):
+                val = spec.get(field)
+                if isinstance(val, str) and "${{" in val:
+                    offenders.append(f"{action_yml.parent.name}:{name}.{field}")
+    assert not offenders, (
+        "GitHub expressions in action input description/default are evaluated at "
+        f"manifest load and can crash the action: {offenders}"
+    )
+
+
+def _jobs(path: Path):
+    data = yaml.safe_load(path.read_text())
+    return data["jobs"]
+
+
+def test_publish_is_gated_on_validation():
+    publish = _jobs(UV_CI)["publish"]
+    needs = publish["needs"]
+    assert "validation" in needs and "setup" in needs
+    cond = publish["if"]
+    # No status function -> implicit success() requires all `needs` to pass,
+    # so a failing validation blocks publish. Reject the escape hatches.
+    assert "cancelled(" not in cond, "publish must not bypass validation via !cancelled()"
+    assert "always(" not in cond, "publish must not run via always()"
+
+
+def test_windows_validation_is_optional_and_separate():
+    jobs = _jobs(UV_CI)
+    win = jobs["windows-validation"]
+    # Windows is continue-on-error and is NOT a publish dependency, so it never
+    # blocks publication.
+    assert win.get("continue-on-error") is True
+    assert "windows-validation" not in jobs["publish"]["needs"]


### PR DESCRIPTION
Follow-up to #45. Fixes two bugs surfaced by [run 26780847263](https://github.com/i2mint/wads/actions/runs/26780847263), which **published 0.1.101 even though validation failed**.

### 1. `export-ci-env` action crashed at manifest load
The `secrets-json` input's *description* contained a literal `${{ toJSON(secrets) }}`. GitHub evaluates expressions even inside description strings when loading the manifest, and the `secrets` context isn't available in a composite-action manifest → `Unrecognized named-value: 'secrets'`, failing the whole validation job in ~4s. Reworded to plain prose (the actual `toJSON(secrets)` is passed from the workflow, which is correct).

### 2. Publish was not gated on validation
`uv-ci.yml`'s publish `if:` used `!cancelled() && needs.setup.result == 'success'` — a deliberate "tests don't block publish" policy that let publish run when `validation` failed (which is how 0.1.101 shipped from a red commit). Removed the status-function escape hatch so the implicit `success()` requires **both `setup` and the Linux `validation` matrix (3.10 + 3.12)** to pass before publishing. Windows stays optional (separate `continue-on-error` job, not a publish dependency). This matches the inline `github_ci_uv.yml` template, which was already correct.

### Tests
`wads/tests/test_workflow_gates.py` pins both invariants: no action input embeds a `${{ }}` expression, and publish gates on validation with no `cancelled()`/`always()` bypass.

> **Note on CI for this PR:** it runs against the *current* (broken) `uv-ci.yml@master`, so this PR's own validation will fail at the action-load step — a bootstrap artifact, not a problem with the fix. Merging puts the fix on master; the post-merge run is the real verification.
