### PR TITLE
Publish gate → default branch + docs/skills alignment + 0.2.1 baseline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ Wads automates Python project setup, packaging, CI/CD, and migration. It provide
 
 ## Architecture: pyproject.toml as Single Source of Truth
 
-The core design principle: **all project configuration lives in `pyproject.toml`**. The CI workflow template (`github_ci_publish_2025.yml`) reads configuration from `pyproject.toml` via the `read-ci-config` action, so projects don't hardcode settings in workflow files.
+The core design principle: **all project configuration lives in `pyproject.toml`**. The default CI is a small stub (`.github/workflows/ci.yml`) that calls the reusable workflow `i2mint/wads/.github/workflows/uv-ci.yml@master`, which reads configuration from `pyproject.toml` via the `read-ci-config` action — so projects don't hardcode settings in workflow files. (`github_ci_publish_2025.yml` is the legacy template; `github_ci_uv.yml` is the inline escape valve.)
 
 ### Key Configuration Sections
 
@@ -139,16 +139,16 @@ To use a secret: `wads-secrets add VAR_NAME [SECRET_NAME]` updates both layers
 needs a one-line PR to `wads.ci_secrets` (or the inline escape valve); the CLI
 warns when that's the case.
 
-### CI Workflow Flow (github_ci_publish_2025.yml)
+### CI Workflow Flow (uv-ci.yml — the reusable workflow)
 
 The CI workflow has 4-5 jobs:
 
-1. **setup** - Reads `[tool.wads.ci]` config, exports as outputs
+1. **setup** - Reads `[tool.wads.ci]` config (incl. `[tool.wads.ci.env]`), exports as outputs
 2. **validation** - Matrix testing across python_versions:
-   - Install system deps → Install Python deps → Ruff format → Ruff lint → Pytest → Metrics
-3. **windows-validation** (optional) - Same tests on Windows, `continue-on-error: true`
-4. **publish** (main/master only) - Format → Bump version → Build → PyPI upload → Commit → Tag
-5. **github-pages** (optional) - Publish docs via epythet
+   - Install system deps → Install Python deps → **export-ci-env** (write declared secrets to `$GITHUB_ENV`, fail on missing required) → Ruff format → Ruff lint → Pytest → Metrics
+3. **windows-validation** (optional) - Same tests on Windows, `continue-on-error: true` (never blocks publish)
+4. **publish** - Runs **only on the repo's default branch**, **only if `validation` succeeded** (the Linux matrix; the `if:` has no `!cancelled()`/`always()` escape hatch), not `[skip ci]`, and publishing enabled. Format → Bump version → Build → PyPI upload → Commit → Tag (push-back via `GITHUB_TOKEN`)
+5. **github-pages** (optional) - Publish docs via epythet (also default-branch-gated)
 
 ### Migration Flow
 

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -379,7 +379,7 @@ jobs:
     name: Publish
     permissions:
       contents: write
-    if: "!contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
+    if: "!contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
     needs: [setup, validation]
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/handoffs/
 .claude/scratch/
+.claude/scheduled_tasks.lock
 docs/*
 wads_configs.json
 data/wads_configs.json

--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ sdist = true
 wheel = true
 ```
 
+The default `ci.yml` is a small stub that calls wads's reusable workflow
+(`i2mint/wads/.github/workflows/uv-ci.yml@master`); all behavior is driven by
+`[tool.wads.ci.*]` above. Publishing to PyPI happens automatically on your
+repo's **default branch** — but only when the Linux test matrix passes.
+
+### Configure Secrets (CI environment variables)
+
+If your tests need API keys or other secrets, declare them once and let wads
+wire up both the GitHub Actions transport and the job environment:
+
+```bash
+wads-secrets add OPENAI_API_KEY            # env var == GitHub secret name
+wads-secrets add HF_TOKEN HF_WRITE_TOKEN    # env var <- differently-named secret
+wads-secrets add DATABASE_URL --kind required   # fail CI if the secret is unset
+wads-secrets list                           # show what's configured
+```
+
+`wads-secrets add` (a) records the variable in `[tool.wads.ci.env]`, (b) adds
+the pass-through line to your `ci.yml`, and (c) runs `gh secret set` if `gh` is
+installed (value taken from `$VAR_NAME` or `--value`). Under the hood there are
+two layers: a **transport superset** (the secret names the reusable workflow can
+receive, in `wads.ci_secrets.DEFAULT_CI_SECRETS`) and an **env policy**
+(`[tool.wads.ci.env]` — `required_envvars` / `test_envvars` / `extra_envvars` /
+`defaults` / `secret_aliases`) that decides which become job env vars. A
+`required` secret that's missing fails the build; an undeclared secret is never
+written to the environment. To use a name outside the superset, open a one-line
+PR to wads or use the inline-workflow escape valve.
+
 ### Declare System Dependencies
 
 Need ffmpeg, ODBC drivers, or other system packages in CI? Declare them in `pyproject.toml`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wads"
-version = "0.1.102"
+version = "0.2.0"
 description = "Tools for packaging and publishing to pypi for those who just do not want to deal with it"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wads/data/github_ci_uv.yml
+++ b/wads/data/github_ci_uv.yml
@@ -175,7 +175,7 @@ jobs:
     name: Publish
     permissions:
       contents: write
-    if: "!contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
+    if: "!contains(github.event.head_commit.message, needs.setup.outputs.skip-ci-marker) && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (needs.setup.outputs.publish-enabled == 'true' || contains(github.event.head_commit.message, needs.setup.outputs.publish-marker))"
     needs: [setup, validation]
     runs-on: ubuntu-latest
 

--- a/wads/data/skills/wads-migrate/SKILL.md
+++ b/wads/data/skills/wads-migrate/SKILL.md
@@ -31,8 +31,8 @@ as an escape valve for repos that need to customize CI beyond `[tool.wads.ci.*]`
 |---|---|
 | Bad wads merge breaks CI everywhere on next run | Wads's own CI runs the reusable workflow first — canary catches obvious breaks. **Crucially: broken CI ≠ broken release.** Publish is gated on workflow success, so a bad wads change blocks publication for downstream consumers until wads is fixed, but never ships a broken artifact. This is what makes floating `@master` safe by default. |
 | Floating `@master` means consumers can't pin a known-good wads state | `wads-migrate ci-to-stub --pin @v0.1.81` writes the stub with a tag pin instead of `@master`. The pinned repo only picks up wads updates when explicitly re-pinned. Use for release-sensitive repos. |
-| Reusable workflow has a curated env-var list (PROJECT_NAME, OPENAI_API_KEY, ANTHROPIC_API_KEY, HF_TOKEN, HUGGINGFACE_TOKEN, KAGGLE_USERNAME, KAGGLE_KEY). Other workflow-level secret env vars need to land in wads. | For one-off needs, use the escape valve (drop the stub, copy `github_ci_uv.yml` inline). For ecosystem-wide needs, PR to wads adding the var to the reusable workflow's top-level `env:` block. |
-| Reusable workflow can't access caller-only secrets without `secrets: inherit` | The stub always sets `secrets: inherit`. Don't remove it. |
+| A secret your tests need isn't reaching CI | Run `wads-secrets add VAR_NAME` (see "Secrets" below). It declares the var in `[tool.wads.ci.env]` AND adds the pass-through line to the stub. No workflow edit needed unless the name is outside the wads superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`), in which case the CLI warns and you either PR wads to widen the superset or use the inline escape valve. |
+| Secrets must reach a reusable workflow owned by a different account | The stub passes secrets **explicitly** (NOT `secrets: inherit`, which is unreliable cross-owner). The stub's `secrets:` block lists each name; it's generated from `[tool.wads.ci.env]` at migrate time and extended by `wads-secrets add`. |
 
 ## Detecting Current Format
 
@@ -151,22 +151,60 @@ pytest collection will fail during import.
 in pyproject.toml, then `wads-migrate ci-to-uv` to re-render the workflow with
 a top-level `env:` block wiring `${{ secrets.X || '' }}`. Set the GitHub secret.
 
-**For stub repos**: the reusable workflow has a curated set of common env vars
-already (OPENAI_API_KEY, ANTHROPIC_API_KEY, HF_TOKEN, HUGGINGFACE_TOKEN,
-KAGGLE_USERNAME, KAGGLE_KEY). Just set the GitHub secret in the consuming
-repo — no workflow edit needed. If the var isn't in the curated set, either:
-- PR to wads adding it to the reusable workflow's `env:` block (ecosystem-wide), or
-- Drop the stub and use inline `github_ci_uv.yml` (one-off).
+**For stub repos** (the default since wads 0.1.82): the simplest path is
 
-Do NOT hand-edit job-level `env:` blocks in ci.yml — they'll be wiped on next
-migrate. Always wire via `[tool.wads.ci.env]` (inline) or PR to wads (stub).
+```bash
+wads-secrets add OPENAI_API_KEY          # VAR == secret name
+wads-secrets add HF_TOKEN HF_WRITE_TOKEN  # env var <- aliased secret
+wads-secrets add DB_URL --kind required   # fail CI if unset
+```
+
+This (a) declares the var in `[tool.wads.ci.env]` so the `export-ci-env` step
+writes it into the job environment, (b) adds the pass-through line to the stub's
+`secrets:` block so the secret is transported to the reusable workflow, and (c)
+`gh secret set`s the value if `gh` is installed (value from `$VAR_NAME` or
+`--value`). See the **Secrets** section below for the full model. If the secret
+name is outside the wads superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`), the CLI
+warns; either PR wads to widen the superset (one line, ecosystem-wide) or use the
+inline `github_ci_uv.yml` escape valve.
+
+Do NOT hand-edit job-level `env:` blocks in ci.yml. Declare via
+`[tool.wads.ci.env]` (or `wads-secrets add`, which is the safe way to do both).
+
+## Secrets (two-layer model)
+
+Secrets reach a stub repo's CI through two coordinated layers:
+
+1. **Transport** — the stub's `secrets:` block *passes* named secrets to the
+   reusable workflow. Explicit pass-through is used (NOT `secrets: inherit`,
+   which is unreliable across GitHub accounts). The *universe* of passable
+   names is the superset declared in the wads-side `uv-ci.yml`
+   (`on.workflow_call.secrets`), generated from `wads.ci_secrets.DEFAULT_CI_SECRETS`.
+   Each repo's stub passes only `PYPI_PASSWORD` + the names it actually uses.
+2. **Env-assignment** — `[tool.wads.ci.env]` (`required_envvars`,
+   `test_envvars`, `extra_envvars`, `defaults`, and `secret_aliases` for
+   ENV_VAR≠SECRET_NAME) decides which passed secrets become job env vars. The
+   `export-ci-env` action writes exactly those to `$GITHUB_ENV` and **fails the
+   build** if a `required` secret is unset. A passed-but-undeclared secret is
+   never written to the env (no over-assignment).
+
+**`wads-secrets add VAR_NAME [SECRET_NAME]`** does both layers (+ `gh secret set`)
+in one step — the recommended way. `wads-secrets list` shows what's configured;
+`wads-secrets superset` prints the allowed names. For a name outside the
+superset: PR `wads.ci_secrets.DEFAULT_CI_SECRETS` (benefits all repos) or use the
+inline `github_ci_uv.yml` escape valve.
+
+Publishing runs only on the repo's **default branch**, when validation passes,
+when the commit isn't `[skip ci]`, and when `[tool.wads.ci.publish].enabled`.
 
 ## Checklist After Migration
 
 - [ ] `pyproject.toml` has correct metadata (name, version, dependencies)
 - [ ] `[tool.wads.ci]` section present (or defaults are acceptable)
-- [ ] `[tool.wads.ci.env.test_envvars]` lists any secrets the code needs at import time
-- [ ] `.github/workflows/ci.yml` is either the 5-line stub OR uses `astral-sh/setup-uv` with a top-level `env:` block
+- [ ] Secrets the code needs are configured via `wads-secrets add` (declares in
+      `[tool.wads.ci.env]` AND passes them in the stub's `secrets:` block)
+- [ ] `.github/workflows/ci.yml` is the stub (calls `uv-ci.yml@master`) OR the
+      inline `github_ci_uv.yml` escape valve
 - [ ] `PYPI_PASSWORD` secret is a PyPI API token
 - [ ] `setup.cfg` and `setup.py` removed (if migrated from old format)
 - [ ] Push to non-main branch to test CI before merging

--- a/wads/tests/test_uv_workflow_template.py
+++ b/wads/tests/test_uv_workflow_template.py
@@ -143,12 +143,14 @@ class TestUvWorkflowTemplate:
         assert "python-version" in validation_job["strategy"]["matrix"]
 
     def test_publish_job_conditional(self, template_data):
-        """Test that publish job only runs on main/master."""
+        """Test that publish job only runs on the repo's default branch."""
         publish_job = template_data["jobs"]["publish"]
         assert "if" in publish_job
         condition = publish_job["if"]
         assert "github.ref" in condition
-        assert "master" in condition or "main" in condition
+        # Gates on the actual default branch (not a literal master/main), so it
+        # stays correct for repos whose default branch is named differently.
+        assert "github.event.repository.default_branch" in condition
 
     def test_setup_job_exposes_publish_gate_outputs(self, template_data):
         """Test setup job exposes the publish gate outputs for the publish job."""

--- a/wads/tests/test_workflow_gates.py
+++ b/wads/tests/test_workflow_gates.py
@@ -48,8 +48,21 @@ def test_publish_is_gated_on_validation():
     cond = publish["if"]
     # No status function -> implicit success() requires all `needs` to pass,
     # so a failing validation blocks publish. Reject the escape hatches.
-    assert "cancelled(" not in cond, "publish must not bypass validation via !cancelled()"
+    assert "cancelled(" not in cond, (
+        "publish must not bypass validation via !cancelled()"
+    )
     assert "always(" not in cond, "publish must not run via always()"
+
+
+def test_publish_gates_on_actual_default_branch():
+    """Publish must key off the repo's real default branch, not a literal master/main.
+
+    Keeps publish and github-pages consistent and correct for repos whose
+    default branch is neither 'master' nor 'main'.
+    """
+    cond = _jobs(UV_CI)["publish"]["if"]
+    assert "github.event.repository.default_branch" in cond
+    assert "refs/heads/master" not in cond and "refs/heads/main" not in cond
 
 
 def test_windows_validation_is_optional_and_separate():


### PR DESCRIPTION
Pre-fleet-migration release. Three things:

### 1. Publish gates on the repo's actual default branch
Both `uv-ci.yml` and the inline `github_ci_uv.yml` switched the publish `if:` from a literal `master || main` to:
```
github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
```
This matches the `github-pages` job and is correct for repos whose default branch is neither `master` nor `main` (which previously would never publish), and avoids publishing from a stray non-default `master`/`main` branch. Combined with the prior fix, publish now requires: **default branch + validation green + not `[skip ci]` + publishing enabled.** `test_workflow_gates.py` / `test_uv_workflow_template.py` updated to pin it.

### 2. Version baseline → 0.2.0 (publishes 0.2.1)
The CI auto-bump increments on publish, so setting the baseline to `0.2.0` makes the next publish ship **0.2.1**, as requested.

### 3. Docs & skills aligned with the new wads way
For the upcoming migration of 10–20 repos, the guidance must be correct:
- **`wads-migrate` SKILL.md** (the migration guide; symlinked into `~/.claude/skills/`): removed the stale `secrets: inherit` claim and the old "curated env-var list" text; documented `wads-secrets add` and the transport-vs-env-policy two-layer model + new **Secrets** section.
- **README.md**: new "Configure Secrets" section (`wads-secrets`, `[tool.wads.ci.env]`, the superset) and a note that publishing happens on the default branch only when validation passes.
- **CLAUDE.md**: replaced legacy `github_ci_publish_2025.yml` references with the stub/`uv-ci.yml`; documented the `export-ci-env` step and the validation-gated, default-branch publish flow.

`wads-ci-fix` and `wads-ci-sweep` skills were reviewed and are already accurate.

Full suite: **286 passed.**

> As with the earlier reusable-workflow fixes, this PR's own CI runs against the current `@master` workflow; the publish/branch-gate change takes effect for consumers once merged. The post-merge run on master is the real verification and will publish 0.2.1.
