### PR TITLE
Single JSON secret transport for the reusable CI workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,7 +100,7 @@ consumer on their next CI run — no per-repo edit, no `wads-migrate` sweep.
 | Tradeoff | Pin strategy |
 |---|---|
 | Float with wads (default) | `@master` — convenient; bad wads merge breaks CI everywhere on next run, but never reaches PyPI (publish is gated on workflow success) |
-| Freeze | `@v0.1.81` (or any tag) — set via `wads-migrate ci-to-stub --pin @v0.1.81`; the repo only picks up wads updates when re-pinned |
+| Freeze | `@0.2.15` (or any later tag; no `v` prefix) — set via `wads-migrate ci-to-stub --pin @0.2.15`; the repo only picks up wads updates when re-pinned. A JSON-transport stub needs a tag whose uv-ci.yml declares `WADS_CI_SECRETS_JSON` (releases after 0.2.14); older pins need `--transport named` |
 
 The "CI failure ≠ broken release" property is what makes `@master` safe by
 default: a botched wads update blocks publication of all downstream packages

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,32 +112,45 @@ most customization belongs in `[tool.wads.ci.*]`), it can replace the stub with
 a copy of `wads/data/github_ci_uv.yml` inline. The repo then owns CI updates
 manually. Convert back to stub later with `wads-migrate ci-to-stub`.
 
-### Secrets / CI env vars — two layers (issue #45)
+### Secrets / CI env vars — two layers (issues #45, #63)
 
 A reusable workflow's secret *interface* (`on.workflow_call.secrets`) must be
 static YAML and `secrets: inherit` is unreliable cross-owner, so secrets are
 handled in two decoupled layers:
 
-1. **Transport** — the caller stub *explicitly passes* named secrets. The
-   universe of passable names is the **superset** declared in `uv-ci.yml`'s
-   `on.workflow_call.secrets`, generated from `wads.ci_secrets.DEFAULT_CI_SECRETS`
-   (the SSOT; a test in `test_ci_secrets.py` pins the YAML to it). Each repo's
-   stub passes only a *small subset* — `PYPI_PASSWORD` plus whatever its
-   `[tool.wads.ci.env]` declares (rendered via `CIConfig.generate_stub_secrets_block`
-   into the stub's `#SECRETS_BLOCK#` placeholder at populate/migrate time).
-2. **Env-assignment** — *which* passed secrets become job env vars (and which
-   are required) is driven entirely by `[tool.wads.ci.env]` (`required_envvars`,
+1. **Transport** — the modern stub passes ONE statically-declared secret,
+   `WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}` — the caller's whole
+   secrets context, double-encoded so the value is single-line (a multiline
+   secret is masked per line, and the pretty-printed `{`/`}` lines would
+   become global masks mangling every brace in the log). Any secret name a
+   repo has reaches the workflow — nothing to enumerate, nothing to fall
+   outside of. The 62-name superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`) is
+   still declared in `uv-ci.yml` but **frozen**: it exists only so old
+   named-transport stubs keep working (a test in `test_ci_secrets.py` pins the
+   YAML to `WORKFLOW_CALL_SECRETS` = JSON secret + superset). Named transport
+   remains available for minimal-secret-surface repos via
+   `wads-migrate ci-to-stub --transport named`, which warns loudly on
+   out-of-superset names (they make the workflow unstartable — issue #63).
+2. **Env-assignment** — *which* values become job env vars (and which are
+   required) is driven entirely by `[tool.wads.ci.env]` (`required_envvars`,
    `test_envvars`, `extra_envvars`, `defaults`, and `secret_aliases` for
    ENV_VAR≠SECRET_NAME). The `export-ci-env` action (`wads/scripts/export_ci_env.py`)
-   reads these via `read-ci-config` outputs and `toJSON(secrets)`, writes exactly
-   the declared vars to `$GITHUB_ENV`, and **fails fast** on a missing required
-   secret. A passed-but-undeclared secret is never written to the environment —
-   so no over-assignment, and no silent under-coverage.
+   reads these via `read-ci-config` outputs plus `toJSON(secrets)` /
+   `toJSON(vars)`, resolves each declared name **secrets-first then repo
+   variables** (the `vars` context resolves to the caller's repo in a reusable
+   workflow — the right home for non-sensitive values like a test level),
+   re-masks blob-sourced values with `::add-mask::`, writes exactly the
+   declared vars to `$GITHUB_ENV`, and **fails fast** on a missing required
+   value. An undeclared secret is never written to the environment — so no
+   over-assignment, and no silent under-coverage. The publish job resolves
+   `PYPI_PASSWORD` through the same step (`always-required` input) so either
+   transport feeds it.
 
-To use a secret: `wads-secrets add VAR_NAME [SECRET_NAME]` updates both layers
-(pyproject + stub) and can `gh secret set` the value. A name outside the superset
-needs a one-line PR to `wads.ci_secrets` (or the inline escape valve); the CLI
-warns when that's the case.
+To use a secret: `wads-secrets add VAR_NAME [SECRET_NAME]` updates pyproject
+(and, on legacy named stubs, the stub's pass-through) and can `gh secret set`
+the value. For non-sensitive values use `wads-secrets add NAME --variable`
+(repo variable; no transport, no masking) or put a literal in
+`[tool.wads.ci.env].defaults`.
 
 ### CI Workflow Flow (uv-ci.yml — the reusable workflow)
 

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -268,7 +268,7 @@ jobs:
       # `vars` resolves to the CALLER repo's configuration variables, so a
       # declared name with no backing secret falls back to a repo variable.
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
+        uses: i2mint/wads/actions/export-ci-env@master
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}
@@ -351,7 +351,7 @@ jobs:
           extras: ${{ needs.setup.outputs.install-extras }}
 
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
+        uses: i2mint/wads/actions/export-ci-env@master
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}
@@ -418,7 +418,7 @@ jobs:
       # uses (named pass-through or the WADS_CI_SECRETS_JSON blob), and fail
       # fast — before the version bump — when it is missing entirely.
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
+        uses: i2mint/wads/actions/export-ci-env@master
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -268,7 +268,7 @@ jobs:
       # `vars` resolves to the CALLER repo's configuration variables, so a
       # declared name with no backing secret falls back to a repo variable.
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@master
+        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}
@@ -351,7 +351,7 @@ jobs:
           extras: ${{ needs.setup.outputs.install-extras }}
 
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@master
+        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}
@@ -418,7 +418,7 @@ jobs:
       # uses (named pass-through or the WADS_CI_SECRETS_JSON blob), and fail
       # fast — before the version bump — when it is missing entirely.
       - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@master
+        uses: i2mint/wads/actions/export-ci-env@issue-63-json-secret-transport
         with:
           required: ${{ needs.setup.outputs.env-required }}
           test: ${{ needs.setup.outputs.env-test }}

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -414,21 +414,6 @@ jobs:
           python-version: ${{ fromJson(needs.setup.outputs.python-versions)[0] }}
           create-venv: "false"
 
-      # Resolve PYPI_PASSWORD into the job env whichever transport the stub
-      # uses (named pass-through or the WADS_CI_SECRETS_JSON blob), and fail
-      # fast — before the version bump — when it is missing entirely.
-      - name: Export CI Environment
-        uses: i2mint/wads/actions/export-ci-env@master
-        with:
-          required: ${{ needs.setup.outputs.env-required }}
-          test: ${{ needs.setup.outputs.env-test }}
-          extra: ${{ needs.setup.outputs.env-extra }}
-          defaults: ${{ needs.setup.outputs.env-defaults }}
-          aliases: ${{ needs.setup.outputs.env-aliases }}
-          secrets-json: ${{ toJSON(secrets) }}
-          vars-json: ${{ toJSON(vars) }}
-          always-required: '["PYPI_PASSWORD"]'
-
       - name: Format Source Code
         if: needs.setup.outputs.ruff-enabled != 'false'
         run: uvx ruff format .
@@ -447,10 +432,29 @@ jobs:
           sdist: ${{ needs.setup.outputs.build-sdist }}
           wheel: ${{ needs.setup.outputs.build-wheel }}
 
-      # env.PYPI_PASSWORD is written by the export step above (it resolves the
-      # token from either transport); the direct secrets reference keeps old
-      # named-transport stubs working even while an older published wads (one
-      # without always-required support) is what the export step installed.
+      # Resolve PYPI_PASSWORD into the job env whichever transport the stub
+      # uses (named pass-through or the WADS_CI_SECRETS_JSON blob), failing
+      # with a clear message when it is missing entirely. Deliberately does
+      # NOT export the repo's declared test env vars (empty required/test/
+      # extra): no tests run in this job, and repo code that runs here —
+      # build hooks, version-bump scripts — must not see test secrets. Also
+      # deliberately placed AFTER the version bump and build, so those steps
+      # run with no secrets in the environment at all.
+      - name: Resolve PyPI token
+        uses: i2mint/wads/actions/export-ci-env@master
+        with:
+          required: '[]'
+          test: '[]'
+          extra: '[]'
+          defaults: ${{ needs.setup.outputs.env-defaults }}
+          aliases: ${{ needs.setup.outputs.env-aliases }}
+          secrets-json: ${{ toJSON(secrets) }}
+          always-required: '["PYPI_PASSWORD"]'
+
+      # env.PYPI_PASSWORD is written by the resolve step above (it resolves
+      # the token from either transport); the direct secrets reference keeps
+      # old named-transport stubs working even while an older published wads
+      # (one without always-required support) is what the step installed.
       - name: Publish to PyPI
         uses: i2mint/wads/actions/pypi-publish-uv@master
         with:

--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -6,19 +6,22 @@ name: Continuous Integration (uv, reusable)
 # section, read by the setup job below.
 #
 # SECRETS — two layers (see wads/ci_secrets.py for the full rationale):
-#   1. Transport: the caller stub explicitly passes named secrets (cross-owner
-#      `secrets: inherit` is unreliable, so we never rely on it). The
-#      `on.workflow_call.secrets` block below is the *superset* of names a
-#      stub may pass — the universe of allowed secret names. It is generated
-#      from wads.ci_secrets.DEFAULT_CI_SECRETS and pinned by a wads test.
-#   2. Env-assignment: which of those secrets actually become job environment
-#      variables (and which are required) is driven entirely by the caller's
+#   1. Transport: the modern stub passes ONE secret, WADS_CI_SECRETS_JSON —
+#      the caller's whole `secrets` context, double-JSON-encoded
+#      (`toJSON(toJSON(secrets))`, single-line so per-line masking can't
+#      register `{`/`}` as global masks). Any secret name a repo has is
+#      transported; there is no fixed list to fall outside of (issue #63).
+#      The remaining named declarations below are the FROZEN legacy superset,
+#      kept only so older stubs that pass named subsets keep working.
+#      (Cross-owner `secrets: inherit` is unreliable, so we never rely on it.)
+#   2. Env-assignment: which secrets actually become job environment variables
+#      (and which are required) is driven entirely by the caller's
 #      [tool.wads.ci.env], applied by the `export-ci-env` action below. A
-#      passed-but-unconfigured secret is never written to the environment.
-#
-# To use a secret whose name is NOT in the superset below: either add it here
-# via a PR to wads (one line, benefits everyone) or inline the full workflow
-# (escape valve) by replacing the stub with a copy of wads/data/github_ci_uv.yml.
+#      transported-but-unconfigured secret is never written to the
+#      environment. Non-sensitive values need no secret at all: use
+#      [tool.wads.ci.env].defaults (committed literals) or repository
+#      *variables* — the caller's `vars` context resolves inside this
+#      workflow and export-ci-env falls back to it per declared name.
 
 on:
   workflow_call:
@@ -32,12 +35,17 @@ on:
         required: false
         default: ""
 
-    # ─── SECRET SUPERSET (generated from wads.ci_secrets.DEFAULT_CI_SECRETS) ───
-    # Every entry is `required: false`; the caller stub passes only the subset
-    # its pyproject declares. Run-time enforcement of required secrets happens
-    # in the export-ci-env step (and PYPI_PASSWORD in the publish job).
-    # Edit wads/ci_secrets.py, not this block by hand — a test pins them equal.
+    # ─── SECRETS (generated from wads.ci_secrets.WORKFLOW_CALL_SECRETS) ───
+    # WADS_CI_SECRETS_JSON is the modern transport: the caller's whole secrets
+    # context as one double-encoded JSON secret. The named entries after it
+    # are the FROZEN legacy superset (back-compat for named-transport stubs).
+    # Every entry is `required: false`; run-time enforcement of required
+    # secrets happens in the export-ci-env step (and PYPI_PASSWORD in the
+    # publish job). Edit wads/ci_secrets.py, not this block by hand — a test
+    # pins them equal.
     secrets:
+      WADS_CI_SECRETS_JSON:
+        required: false
       PYPI_PASSWORD:
         required: false
       TEST_PYPI_PASSWORD:
@@ -257,6 +265,8 @@ jobs:
 
       # Write the pyproject-declared env vars into $GITHUB_ENV (and fail fast
       # if a required secret is missing). Driven by [tool.wads.ci.env].
+      # `vars` resolves to the CALLER repo's configuration variables, so a
+      # declared name with no backing secret falls back to a repo variable.
       - name: Export CI Environment
         uses: i2mint/wads/actions/export-ci-env@master
         with:
@@ -266,6 +276,7 @@ jobs:
           defaults: ${{ needs.setup.outputs.env-defaults }}
           aliases: ${{ needs.setup.outputs.env-aliases }}
           secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
 
       - name: Format Source Code
         if: needs.setup.outputs.ruff-enabled != 'false'
@@ -348,6 +359,7 @@ jobs:
           defaults: ${{ needs.setup.outputs.env-defaults }}
           aliases: ${{ needs.setup.outputs.env-aliases }}
           secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
 
       - name: Run Tests
         uses: i2mint/wads/actions/run-tests-uv@master
@@ -402,6 +414,21 @@ jobs:
           python-version: ${{ fromJson(needs.setup.outputs.python-versions)[0] }}
           create-venv: "false"
 
+      # Resolve PYPI_PASSWORD into the job env whichever transport the stub
+      # uses (named pass-through or the WADS_CI_SECRETS_JSON blob), and fail
+      # fast — before the version bump — when it is missing entirely.
+      - name: Export CI Environment
+        uses: i2mint/wads/actions/export-ci-env@master
+        with:
+          required: ${{ needs.setup.outputs.env-required }}
+          test: ${{ needs.setup.outputs.env-test }}
+          extra: ${{ needs.setup.outputs.env-extra }}
+          defaults: ${{ needs.setup.outputs.env-defaults }}
+          aliases: ${{ needs.setup.outputs.env-aliases }}
+          secrets-json: ${{ toJSON(secrets) }}
+          vars-json: ${{ toJSON(vars) }}
+          always-required: '["PYPI_PASSWORD"]'
+
       - name: Format Source Code
         if: needs.setup.outputs.ruff-enabled != 'false'
         run: uvx ruff format .
@@ -420,10 +447,14 @@ jobs:
           sdist: ${{ needs.setup.outputs.build-sdist }}
           wheel: ${{ needs.setup.outputs.build-wheel }}
 
+      # env.PYPI_PASSWORD is written by the export step above (it resolves the
+      # token from either transport); the direct secrets reference keeps old
+      # named-transport stubs working even while an older published wads (one
+      # without always-required support) is what the export step installed.
       - name: Publish to PyPI
         uses: i2mint/wads/actions/pypi-publish-uv@master
         with:
-          pypi-token: ${{ secrets.PYPI_PASSWORD }}
+          pypi-token: ${{ secrets.PYPI_PASSWORD || env.PYPI_PASSWORD }}
 
       - name: Commit Changes
         uses: i2mint/wads/actions/git-commit@master

--- a/README.md
+++ b/README.md
@@ -143,9 +143,14 @@ name resolves against secrets first, then repository *variables* (the right
 home for non-sensitive values); committed constants can go straight into
 `[tool.wads.ci.env].defaults`. A `required` name that resolves to nothing
 fails the build; an undeclared secret is never written to the environment.
-(Older stubs pass secrets by name instead and are limited to the frozen
-superset in `wads.ci_secrets.DEFAULT_CI_SECRETS`; regenerate with
-`wads-migrate ci-to-stub` to switch to the JSON transport.)
+Note the JSON transport hands **every** secret the repo can read — including
+org-level ones — to the reusable workflow (which only exports the declared
+ones). If you want the workflow to receive *only* the names you list, use
+`wads-migrate ci-to-stub --transport named` — that mode is limited to the
+frozen superset in `wads.ci_secrets.DEFAULT_CI_SECRETS`, and is also the
+right choice for orgs with very large shared secrets (the serialized context
+must fit in one secret value). Older stubs pass secrets by name the same way;
+regenerate with `wads-migrate ci-to-stub` to switch to the JSON transport.
 
 ### Declare System Dependencies
 

--- a/README.md
+++ b/README.md
@@ -127,19 +127,25 @@ wire up both the GitHub Actions transport and the job environment:
 wads-secrets add OPENAI_API_KEY            # env var == GitHub secret name
 wads-secrets add HF_TOKEN HF_WRITE_TOKEN    # env var <- differently-named secret
 wads-secrets add DATABASE_URL --kind required   # fail CI if the secret is unset
+wads-secrets add TEST_LEVEL --variable      # non-sensitive value -> repo variable
 wads-secrets list                           # show what's configured
 ```
 
-`wads-secrets add` (a) records the variable in `[tool.wads.ci.env]`, (b) adds
-the pass-through line to your `ci.yml`, and (c) runs `gh secret set` if `gh` is
-installed (value taken from `$VAR_NAME` or `--value`). Under the hood there are
-two layers: a **transport superset** (the secret names the reusable workflow can
-receive, in `wads.ci_secrets.DEFAULT_CI_SECRETS`) and an **env policy**
-(`[tool.wads.ci.env]` — `required_envvars` / `test_envvars` / `extra_envvars` /
-`defaults` / `secret_aliases`) that decides which become job env vars. A
-`required` secret that's missing fails the build; an undeclared secret is never
-written to the environment. To use a name outside the superset, open a one-line
-PR to wads or use the inline-workflow escape valve.
+`wads-secrets add` (a) records the variable in `[tool.wads.ci.env]` and (b)
+runs `gh secret set` (or `gh variable set` with `--variable`) if `gh` is
+installed (value taken from `$VAR_NAME` or `--value`). Under the hood there
+are two layers: a **transport** — the stub passes your repo's whole secrets
+context to the reusable workflow as one `WADS_CI_SECRETS_JSON` secret, so any
+secret name works — and an **env policy** (`[tool.wads.ci.env]` —
+`required_envvars` / `test_envvars` / `extra_envvars` / `defaults` /
+`secret_aliases`) that decides which values become job env vars. Each declared
+name resolves against secrets first, then repository *variables* (the right
+home for non-sensitive values); committed constants can go straight into
+`[tool.wads.ci.env].defaults`. A `required` name that resolves to nothing
+fails the build; an undeclared secret is never written to the environment.
+(Older stubs pass secrets by name instead and are limited to the frozen
+superset in `wads.ci_secrets.DEFAULT_CI_SECRETS`; regenerate with
+`wads-migrate ci-to-stub` to switch to the JSON transport.)
 
 ### Declare System Dependencies
 

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -75,9 +75,10 @@ runs:
       # Python code in lockstep — before anything is published.
       env:
         WADS_ACTION_REF: ${{ github.action_ref }}
+        WADS_ACTION_REPO: ${{ github.action_repository || 'i2mint/wads' }}
       run: |
         if [ -n "$WADS_ACTION_REF" ] && [ "$WADS_ACTION_REF" != "master" ]; then
-          python -m pip install --quiet "git+https://github.com/i2mint/wads@${WADS_ACTION_REF}"
+          python -m pip install --quiet "git+https://github.com/${WADS_ACTION_REPO}@${WADS_ACTION_REF}"
         else
           python -m pip install --quiet --upgrade 'wads>=0.1.48'
         fi

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -1,11 +1,12 @@
 name: 'Export CI Environment from pyproject.toml'
 description: >-
   Write the pyproject-declared environment variables into $GITHUB_ENV. Exports
-  only the secrets a repo's [tool.wads.ci.env] declares (plus literal defaults),
-  and fails with a clear message if a required secret is missing. The full
-  secrets context is passed via toJSON(secrets) so no per-secret enumeration is
-  needed here — the transport superset is enumerated in the workflow's
-  on.workflow_call.secrets block instead.
+  only the values a repo's [tool.wads.ci.env] declares (plus literal defaults),
+  resolving each name against secrets first (including the WADS_CI_SECRETS_JSON
+  transport blob, whose extracted values are re-masked) and repository
+  variables second, and fails with a clear message if a required value is
+  missing. The full secrets/vars contexts are passed via toJSON so no
+  per-secret enumeration is needed here.
 branding:
   icon: 'lock'
   color: 'blue'
@@ -37,6 +38,19 @@ inputs:
     # `secrets` context is not available in a composite action manifest.
     description: 'The secrets context serialized as JSON by the caller (toJSON of the secrets context).'
     required: true
+  vars-json:
+    description: >-
+      The caller's configuration-variables context serialized as JSON (toJSON
+      of the vars context). Declared env vars with no backing secret fall back
+      to a same-named repository variable.
+    required: false
+    default: '{}'
+  always-required:
+    description: >-
+      JSON array of env-var names the WORKFLOW itself requires (merged with the
+      repo-declared required_envvars), e.g. PYPI_PASSWORD in the publish job.
+    required: false
+    default: '[]'
 
 runs:
   using: 'composite'
@@ -64,6 +78,8 @@ runs:
         WADS_ENV_DEFAULTS: ${{ inputs.defaults }}
         WADS_ENV_ALIASES: ${{ inputs.aliases }}
         WADS_SECRETS_JSON: ${{ inputs.secrets-json }}
+        WADS_VARS_JSON: ${{ inputs.vars-json }}
+        WADS_ENV_ALWAYS_REQUIRED: ${{ inputs.always-required }}
       run: |
         if python -c "import wads.scripts.export_ci_env" 2>/dev/null; then
           python -m wads.scripts.export_ci_env

--- a/actions/export-ci-env/action.yml
+++ b/actions/export-ci-env/action.yml
@@ -62,12 +62,25 @@ runs:
 
     - name: Install wads (for CI env utilities)
       shell: bash
-      # Install the latest published wads (floor is a version that exists, NOT
-      # the one that first shipped this module — pinning a not-yet-published
-      # version would make `pip install` fail during the publish-lag window
-      # after a wads merge). The run step below no-ops if the installed wads is
-      # too old to contain export_ci_env, so it is safe across that window.
-      run: python -m pip install --quiet --upgrade 'wads>=0.1.48'
+      # On master (the production path): install the latest published wads
+      # (floor is a version that exists, NOT the one that first shipped this
+      # module — pinning a not-yet-published version would make `pip install`
+      # fail during the publish-lag window after a wads merge). The run step
+      # below no-ops if the installed wads is too old, so it is safe across
+      # that window.
+      #
+      # On any other ref (github.action_ref = the ref this action was
+      # `uses:`-referenced at): install wads from git at that same ref, so a
+      # wads feature branch can be end-to-end tested — workflow, action, and
+      # Python code in lockstep — before anything is published.
+      env:
+        WADS_ACTION_REF: ${{ github.action_ref }}
+      run: |
+        if [ -n "$WADS_ACTION_REF" ] && [ "$WADS_ACTION_REF" != "master" ]; then
+          python -m pip install --quiet "git+https://github.com/i2mint/wads@${WADS_ACTION_REF}"
+        else
+          python -m pip install --quiet --upgrade 'wads>=0.1.48'
+        fi
 
     - name: Export configured environment
       shell: bash

--- a/wads/ci_secrets.py
+++ b/wads/ci_secrets.py
@@ -1,45 +1,89 @@
 """Canonical registry of CI secret names for wads-managed projects.
 
-This module is the **single source of truth** for the *transport superset*: the
-set of secret names that the reusable wads CI workflow (``uv-ci.yml``) declares
-in ``on.workflow_call.secrets`` and that the caller stub
-(``github_ci_uv_stub.yml``) passes through.
+This module is the single source of truth for the *transport* layer of wads
+CI secrets: what the reusable workflow (``uv-ci.yml``) declares in
+``on.workflow_call.secrets`` and what the caller stub passes.
 
-Why a superset, and why it lives here
---------------------------------------
+Transport: one JSON secret (the modern default)
+-----------------------------------------------
 A GitHub *reusable* workflow's secret interface (``on.workflow_call.secrets``)
 must be **static YAML** — it is parsed before any job runs and cannot be
-parametrized from ``pyproject.toml``. ``secrets: inherit`` is documented to work
-only when caller and callee share an owner (org/enterprise), so it is unusable
-for personal-account repos calling an ``i2mint``-owned workflow. The robust,
-universal choice is therefore to *explicitly pass a generous static superset*.
+parametrized from ``pyproject.toml``. ``secrets: inherit`` is documented to
+work only when caller and callee share an org/enterprise, so it is unusable
+for personal-account repos calling an ``i2mint``-owned workflow.
 
-Passing a superset is harmless: a secret the caller has not set resolves to an
-empty string and — crucially — is **not** written into the job environment.
-*Which* secrets actually land in the job env (and which are required) is a
-separate, dynamic decision driven by ``[tool.wads.ci.env]`` in the consumer's
-``pyproject.toml`` (see :mod:`wads.ci_config` and the ``export-ci-env`` action).
+The static-interface constraint is satisfied with a single statically-declared
+secret, :data:`JSON_TRANSPORT_SECRET` (``WADS_CI_SECRETS_JSON``), whose value
+is the caller's whole ``secrets`` context serialized by the stub::
+
+    secrets:
+      WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}
+
+(The documented context-availability table allows the ``secrets`` context in
+``jobs.<job_id>.secrets.<id>``, so this expression is legal in the caller.)
+With this, *any* secret name a repo has reaches the reusable workflow — there
+is no fixed name list to be "outside of", which eliminates the parse-time
+``startup_failure`` class of issue #63 entirely.
+
+Two details, both verified empirically (see issue #63):
+
+* **Double encoding** (``toJSON(toJSON(...))``) makes the transported value a
+  *single-line* JSON string. A multiline secret is masked per line, and the
+  pretty-printed form's ``{`` / ``}`` lines would become global masks that
+  mangle every brace in the job log. Single-line ⇒ only the whole blob is
+  masked.
+* **Re-masking**: individual values extracted from the blob are *not*
+  automatically masked in the callee, so the ``export-ci-env`` action emits
+  ``::add-mask::`` for each secret-sourced value before exporting it.
+
+*Which* secrets actually land in the job env (and which are required) remains
+a separate, dynamic decision driven by ``[tool.wads.ci.env]`` in the
+consumer's ``pyproject.toml`` (see :mod:`wads.ci_config` and the
+``export-ci-env`` action). Nothing is exported unless declared there.
+
+The named superset (legacy transport, kept for back-compat)
+-----------------------------------------------------------
+Before the JSON transport, the workflow declared a generous *superset* of
+optional secret names (:data:`DEFAULT_CI_SECRETS`) and each repo's stub passed
+a named subset. That design failed whenever a repo needed a name outside the
+superset — GitHub rejects an undeclared secret at parse time with an opaque
+``startup_failure`` (issue #63).
+
+The superset is still declared by ``uv-ci.yml`` so that already-deployed
+named-transport stubs keep working, but it is **frozen**: new names should not
+be added — a repo that needs a new name should switch to the JSON transport
+stub (``wads-migrate ci-to-stub``), which transports everything.
 
 So there are two layers:
 
-* **Transport** — the superset below, rendered into static YAML. Plumbing.
+* **Transport** — the JSON secret (modern) or the frozen superset (legacy),
+  rendered into static YAML. Plumbing.
 * **Env-assignment** — pyproject-driven, exact, per-repo. The thing users tune.
 
-Keeping the list here (Python) and *rendering* it into the YAML (with a test
-pinning the YAML to this list) gives a single SSOT while respecting GitHub's
-parse-time-literal constraint.
+Keeping the names here (Python) and *rendering* them into the YAML (with a
+test pinning the YAML to this module) gives a single SSOT while respecting
+GitHub's parse-time-literal constraint.
 """
 
 import re
 
+# The single statically-declared secret through which a stub transports the
+# caller's whole `secrets` context (double-encoded JSON; see module docstring).
+JSON_TRANSPORT_SECRET = "WADS_CI_SECRETS_JSON"
+
+# The caller-side expression for the JSON transport. Double toJSON keeps the
+# value single-line so per-line masking cannot register `{` / `}` as masks.
+JSON_TRANSPORT_EXPRESSION = "${{ toJSON(toJSON(secrets)) }}"
+
 # ---------------------------------------------------------------------------
-# The canonical superset.
+# The legacy named superset — FROZEN.
 #
 # Grouped only for human readability; the public value is the flat, de-duped,
-# order-preserving tuple ``DEFAULT_CI_SECRETS`` built below. Widening this list
-# is a one-line PR that benefits every wads-managed repo — over-listing is
-# harmless (unset secrets are empty and never exported), so err toward
-# inclusion of widely-used names.
+# order-preserving tuple ``DEFAULT_CI_SECRETS`` built below. It exists so that
+# named-transport stubs deployed before the JSON transport keep working; do
+# not widen it — a repo needing a name outside it should regenerate its stub
+# (`wads-migrate ci-to-stub`), which transports every secret via
+# JSON_TRANSPORT_SECRET.
 # ---------------------------------------------------------------------------
 
 _PUBLISHING = (
@@ -156,7 +200,10 @@ def _dedupe_preserving_order(names):
 DEFAULT_CI_SECRETS = tuple(
     _dedupe_preserving_order(name for group in _GROUPS for name in group)
 )
-"""Ordered, de-duplicated superset of CI secret names (the SSOT)."""
+"""Ordered, de-duplicated legacy superset of named CI secrets (frozen)."""
+
+WORKFLOW_CALL_SECRETS = (JSON_TRANSPORT_SECRET, *DEFAULT_CI_SECRETS)
+"""Every secret ``uv-ci.yml`` declares: the JSON transport + the legacy superset."""
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +299,7 @@ def is_valid_secret_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def render_workflow_call_secrets(names=DEFAULT_CI_SECRETS, *, indent: int = 4) -> str:
+def render_workflow_call_secrets(names=WORKFLOW_CALL_SECRETS, *, indent: int = 4) -> str:
     """Render the ``on.workflow_call.secrets:`` body for the reusable workflow.
 
     Every secret is declared ``required: false`` — the publish job enforces
@@ -276,7 +323,7 @@ def render_workflow_call_secrets(names=DEFAULT_CI_SECRETS, *, indent: int = 4) -
 def render_stub_secrets_passthrough(
     names=DEFAULT_CI_SECRETS, *, indent: int = 6
 ) -> str:
-    """Render the caller stub's ``secrets:`` pass-through block.
+    """Render a caller stub's *named* ``secrets:`` pass-through block (legacy).
 
     >>> print(render_stub_secrets_passthrough(["PYPI_PASSWORD", "NPM_TOKEN"]))
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -284,3 +331,13 @@ def render_stub_secrets_passthrough(
     """
     pad = " " * indent
     return "\n".join(f"{pad}{name}: ${{{{ secrets.{name} }}}}" for name in names)
+
+
+def render_stub_json_transport(*, indent: int = 6) -> str:
+    """Render the caller stub's JSON-transport ``secrets:`` line (the default).
+
+    >>> print(render_stub_json_transport())
+          WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}
+    """
+    pad = " " * indent
+    return f"{pad}{JSON_TRANSPORT_SECRET}: {JSON_TRANSPORT_EXPRESSION}"

--- a/wads/data/github_ci_uv_stub.yml
+++ b/wads/data/github_ci_uv_stub.yml
@@ -29,20 +29,19 @@ jobs:
     permissions:
       contents: write
       pages: write
-    # Explicit pass-through (not `secrets: inherit`) because `inherit` does
-    # not reliably propagate caller-repo secrets to a reusable workflow owned
-    # by a different account (verified empirically: personal-account caller +
-    # i2mint-org workflow → `${{ secrets.PYPI_PASSWORD }}` resolved to empty).
+    # Transport: this repo's whole `secrets` context, serialized into the one
+    # secret the reusable workflow declares. Double-encoded (toJSON twice) so
+    # the value is a single line — a multiline secret would register its `{`
+    # and `}` lines as global log masks. Any secret name works; there is no
+    # fixed list to fall outside of. (Cross-owner `secrets: inherit` does not
+    # propagate secrets, so it cannot replace this.)
     #
-    # This list is the per-repo *transport*: it should contain PYPI_PASSWORD
-    # (for publishing) plus every secret your tests/CI need. It is generated
-    # from [tool.wads.ci.env] in pyproject.toml. To add one, run
-    #   wads-secrets add VAR_NAME            # updates pyproject + this block
-    # or just append a line below. *Which* of these become job env vars (and
-    # which are required) is controlled by [tool.wads.ci.env] — passing a
-    # secret here does not by itself put it in the environment.
-    #
-    # A secret name must also be declared in the reusable workflow's superset
-    # (wads/ci_secrets.py). `wads-secrets add` warns if it is not.
+    # *Which* of these become job env vars — and which are required — is
+    # driven entirely by [tool.wads.ci.env] in pyproject.toml; nothing is
+    # exported unless declared there (`wads-secrets add VAR_NAME` declares
+    # one and can set its value). Non-sensitive values don't need a secret:
+    # use [tool.wads.ci.env].defaults (committed literals) or a repository
+    # *variable* (`gh variable set NAME`) — declared names fall back to
+    # repo variables automatically.
     secrets:
-#SECRETS_BLOCK#
+      WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}

--- a/wads/data/github_ci_uv_stub.yml
+++ b/wads/data/github_ci_uv_stub.yml
@@ -5,7 +5,11 @@
 # full inline template `wads/data/github_ci_uv.yml` from i2mint/wads.
 #
 # Pinning: `@master` floats with wads. If you need version stability for
-# a release-sensitive repo, change `@master` to a wads tag (e.g. `@v0.1.81`).
+# a release-sensitive repo, change `@master` to a wads tag (e.g. `@0.2.15`;
+# tags have no `v` prefix). A stub whose `secrets:` block passes the JSON
+# transport (the default below) needs a tag from a release after 0.2.14 —
+# older tags don't declare that secret and GitHub then rejects the
+# workflow at parse time.
 # CI failure does not block a published release — it blocks the publish
 # step itself — so floating master is generally safe.
 #
@@ -35,6 +39,11 @@ jobs:
     # and `}` lines as global log masks. Any secret name works; there is no
     # fixed list to fall outside of. (Cross-owner `secrets: inherit` does not
     # propagate secrets, so it cannot replace this.)
+    #
+    # Note this hands EVERY secret this repo can read — including org-level
+    # ones — to the called workflow. For a minimal secret surface (only the
+    # names you list), regenerate with
+    #   wads-migrate ci-to-stub --transport named
     #
     # *Which* of these become job env vars — and which are required — is
     # driven entirely by [tool.wads.ci.env] in pyproject.toml; nothing is

--- a/wads/migration.py
+++ b/wads/migration.py
@@ -874,7 +874,11 @@ def migrate_ci_to_stub(
             what was there.
         pin: The wads ref the stub points at. Defaults to ``"@master"``
             (floats with wads). For release-sensitive repos, pin to a tag,
-            e.g. ``pin="@v0.1.81"``. Must start with ``"@"``.
+            e.g. ``pin="@0.2.15"`` (wads tags have no ``v`` prefix). With the
+            default JSON transport the pinned ref's ``uv-ci.yml`` must declare
+            ``WADS_CI_SECRETS_JSON`` (releases after 0.2.14) — pinning an
+            older tag produces a workflow GitHub rejects at parse time, so a
+            warning is emitted for any non-master pin. Must start with ``"@"``.
         transport: ``"json"`` (default) passes the repo's whole secrets
             context as one ``WADS_CI_SECRETS_JSON`` secret — any secret name
             works, nothing to enumerate. ``"named"`` passes an explicit subset
@@ -893,8 +897,8 @@ def migrate_ci_to_stub(
         True
         >>> 'WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}' in stub
         True
-        >>> pinned = migrate_ci_to_stub(pin='@v0.1.81')
-        >>> 'uv-ci.yml@v0.1.81' in pinned
+        >>> pinned = migrate_ci_to_stub(pin='@0.2.15')  # warns on stderr
+        >>> 'uv-ci.yml@0.2.15' in pinned
         True
         >>> named = migrate_ci_to_stub(transport='named')
         >>> 'PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}' in named
@@ -906,6 +910,16 @@ def migrate_ci_to_stub(
         raise ValueError(f"pin must start with '@', got {pin!r}")
     if transport not in ("json", "named"):
         raise ValueError(f"transport must be 'json' or 'named', got {transport!r}")
+    if transport == "json" and pin != "@master":
+        print(
+            f"warning: the JSON-transport stub passes WADS_CI_SECRETS_JSON, "
+            f"which the pinned ref's uv-ci.yml must declare "
+            f"(on.workflow_call.secrets). Tags up to and including 0.2.14 do "
+            f"NOT declare it — a stub pinned to one CANNOT START (parse-time "
+            f"startup_failure). Verify {pin!r} is a release after 0.2.14, or "
+            f"use --transport named for older pins.",
+            file=sys.stderr,
+        )
     with open(github_ci_uv_stub_path) as f:
         stub = f.read()
     if pin != "@master":
@@ -1237,7 +1251,10 @@ def main():
         help=(
             "wads ref to pin in the stub. Defaults to '@master' (floats with "
             "wads — convenient, occasional CI breakage on bad wads merges). "
-            "Use e.g. '@v0.1.81' to freeze. Must start with '@'."
+            "Use e.g. '@0.2.15' to freeze (tags have no 'v' prefix). The "
+            "default JSON transport needs a ref whose uv-ci.yml declares "
+            "WADS_CI_SECRETS_JSON (releases after 0.2.14); for older pins "
+            "use --transport named. Must start with '@'."
         ),
     )
     stub_parser.add_argument(

--- a/wads/migration.py
+++ b/wads/migration.py
@@ -857,6 +857,7 @@ def migrate_ci_to_stub(
     old_ci: Union[str, Path] = None,
     *,
     pin: str = "@master",
+    transport: str = "json",
 ) -> str:
     """Return the SSOT stub CI workflow that calls i2mint/wads's reusable uv-ci.
 
@@ -867,14 +868,21 @@ def migrate_ci_to_stub(
     `i2mint/wads/actions/read-ci-config` action.
 
     Args:
-        old_ci: Optional path or content of the existing CI workflow. Unused
-            for the actual conversion (the stub is the same regardless of
-            what was there), but accepted for symmetry with `migrate_ci_to_uv`
-            and to allow future heuristics (e.g. warn if the existing CI is a
-            customized fork that the stub would silently drop changes from).
+        old_ci: Optional path or content of the existing CI workflow. Used only
+            to locate a nearby pyproject.toml when ``transport="named"``;
+            with the default JSON transport the stub is the same regardless of
+            what was there.
         pin: The wads ref the stub points at. Defaults to ``"@master"``
             (floats with wads). For release-sensitive repos, pin to a tag,
             e.g. ``pin="@v0.1.81"``. Must start with ``"@"``.
+        transport: ``"json"`` (default) passes the repo's whole secrets
+            context as one ``WADS_CI_SECRETS_JSON`` secret — any secret name
+            works, nothing to enumerate. ``"named"`` passes an explicit subset
+            (PYPI_PASSWORD + the [tool.wads.ci.env]-declared secrets) for
+            repos that want a minimal secret surface; every name must then be
+            in the frozen wads superset or GitHub rejects the workflow at
+            parse time (issue #63) — out-of-superset names trigger a loud
+            warning.
 
     Returns:
         The stub workflow content as a string.
@@ -883,45 +891,112 @@ def migrate_ci_to_stub(
         >>> stub = migrate_ci_to_stub()
         >>> 'i2mint/wads/.github/workflows/uv-ci.yml@master' in stub
         True
-        >>> 'PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}' in stub
+        >>> 'WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}' in stub
         True
-        >>> '#SECRETS_BLOCK#' in stub  # placeholder is always filled
-        False
         >>> pinned = migrate_ci_to_stub(pin='@v0.1.81')
         >>> 'uv-ci.yml@v0.1.81' in pinned
         True
+        >>> named = migrate_ci_to_stub(transport='named')
+        >>> 'PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}' in named
+        True
+        >>> 'WADS_CI_SECRETS_JSON' in named
+        False
     """
     if not pin.startswith("@"):
         raise ValueError(f"pin must start with '@', got {pin!r}")
+    if transport not in ("json", "named"):
+        raise ValueError(f"transport must be 'json' or 'named', got {transport!r}")
     with open(github_ci_uv_stub_path) as f:
         stub = f.read()
     if pin != "@master":
         stub = stub.replace("uv-ci.yml@master", f"uv-ci.yml{pin}")
-    # Fill the per-repo transport list from the repo's [tool.wads.ci.env] when a
-    # pyproject.toml is alongside the old CI; otherwise default to publish-only.
-    secrets_block = _stub_secrets_block_for(old_ci)
-    stub = stub.replace("#SECRETS_BLOCK#", secrets_block)
+    if transport == "named":
+        from wads.ci_secrets import (
+            render_stub_json_transport,
+            render_stub_secrets_passthrough,
+        )
+
+        names = _stub_secret_names_for(old_ci)
+        _warn_named_transport_outside_superset(names)
+        # Swap the template's JSON-transport comment paragraph (the lines
+        # from "# Transport:" down to the JSON line) for a named-mode one,
+        # so the stub doesn't describe a transport it isn't using.
+        named_region = (
+            "    # Transport (NAMED, legacy): explicitly passes only the secrets\n"
+            "    # listed below (PYPI_PASSWORD + those declared in\n"
+            "    # [tool.wads.ci.env]). Every name must be in the frozen wads\n"
+            "    # superset (wads/ci_secrets.py) or GitHub rejects the workflow\n"
+            "    # at parse time. The default JSON transport has no such limit;\n"
+            "    # regenerate with `wads-migrate ci-to-stub` to switch.\n"
+            "    secrets:\n" + render_stub_secrets_passthrough(names) + "\n"
+        )
+        json_line = render_stub_json_transport()
+        json_region = re.compile(
+            r"^    # Transport:.*?" + re.escape(json_line) + r"\n",
+            re.DOTALL | re.MULTILINE,
+        )
+        stub, n_replaced = json_region.subn(named_region, stub)
+        if n_replaced != 1:
+            raise ValueError(
+                "stub template changed shape: could not locate the JSON "
+                "transport region to convert to named transport"
+            )
+    # Legacy templates carried a placeholder instead of a transport line.
+    if "#SECRETS_BLOCK#" in stub:
+        from wads.ci_secrets import render_stub_secrets_passthrough
+
+        stub = stub.replace(
+            "#SECRETS_BLOCK#",
+            render_stub_secrets_passthrough(_stub_secret_names_for(old_ci)),
+        )
     return stub
 
 
-def _stub_secrets_block_for(old_ci) -> str:
-    """Render the stub ``secrets:`` block, driven by a nearby pyproject.toml.
+def _stub_secret_names_for(old_ci) -> list:
+    """Secret names a *named-transport* stub should pass, from nearby pyproject.
 
     Looks for a ``pyproject.toml`` next to ``old_ci`` (or in its repo root) and
     uses its ``[tool.wads.ci.env]`` to decide which secrets to transport. Falls
     back to publish-only (``PYPI_PASSWORD``) when no config is available.
     """
-    from wads.ci_secrets import render_stub_secrets_passthrough
-
     pyproject = _find_pyproject_near(old_ci)
     if pyproject is not None:
         try:
             from wads.ci_config import CIConfig
 
-            return CIConfig.from_file(str(pyproject)).generate_stub_secrets_block()
+            return CIConfig.from_file(str(pyproject)).stub_secret_names()
         except Exception:
             pass
-    return render_stub_secrets_passthrough(["PYPI_PASSWORD"])
+    return ["PYPI_PASSWORD"]
+
+
+def _warn_named_transport_outside_superset(names) -> list:
+    """Warn loudly for names a named-transport stub cannot legally pass.
+
+    A caller may only pass secrets the reusable workflow declares. With
+    ``transport="named"`` that universe is the frozen superset in
+    :data:`wads.ci_secrets.DEFAULT_CI_SECRETS`; a stub naming anything outside
+    it produces a workflow GitHub rejects at parse time — zero jobs, an opaque
+    ``startup_failure`` (issue #63). Returns the offending names.
+    """
+    from wads.ci_secrets import DEFAULT_CI_SECRETS
+
+    outside = [n for n in names if n not in DEFAULT_CI_SECRETS]
+    for name in outside:
+        print(
+            f"warning: {name!r} is not in the wads secrets superset, so a stub "
+            f"passing it by name CANNOT START (GitHub rejects the workflow at "
+            f"parse time with `startup_failure`). Either:\n"
+            f"  - if the value is not actually sensitive, store it as a "
+            f"repository VARIABLE (`gh variable set {name}`) — declared env "
+            f"vars fall back to repo variables automatically; or\n"
+            f"  - use the default JSON transport (`wads-migrate ci-to-stub` "
+            f"without --transport named), which passes every secret; or\n"
+            f"  - keep the inline workflow (`wads-migrate ci-to-uv`, don't "
+            f"stub-ify).",
+            file=sys.stderr,
+        )
+    return outside
 
 
 def _find_pyproject_near(old_ci) -> Path | None:
@@ -1165,6 +1240,19 @@ def main():
             "Use e.g. '@v0.1.81' to freeze. Must start with '@'."
         ),
     )
+    stub_parser.add_argument(
+        "--transport",
+        default="json",
+        choices=("json", "named"),
+        help=(
+            "How the stub passes secrets to the reusable workflow. 'json' "
+            "(default) serializes the repo's whole secrets context into one "
+            "WADS_CI_SECRETS_JSON secret — any secret name works. 'named' "
+            "passes an explicit subset (minimal secret surface), but every "
+            "name must be in the frozen wads superset or the workflow cannot "
+            "start."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1304,7 +1392,9 @@ def main():
             if pyproject is not None:
                 carried = carry_ci_env_into_pyproject(existing, pyproject)
 
-            result = migrate_ci_to_stub(str(input_path), pin=args.pin)
+            result = migrate_ci_to_stub(
+                str(input_path), pin=args.pin, transport=args.transport
+            )
 
             output_path = Path(args.output) if args.output else input_path
             output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/wads/populate.py
+++ b/wads/populate.py
@@ -1080,9 +1080,10 @@ def _add_ci_def(
             # Basic substitutions for static template
             ci_def = ci_def.replace("#PROJECT_NAME#", name)
 
-        # The SSOT stub carries a #SECRETS_BLOCK# placeholder (the per-repo
-        # transport list). The dynamic path fills it from [tool.wads.ci.env];
-        # otherwise fall back to the publish-only default so the stub is valid.
+        # Legacy templates carried a #SECRETS_BLOCK# placeholder (per-repo
+        # named transport). The current stub template passes the whole secrets
+        # context as one WADS_CI_SECRETS_JSON secret and has no placeholder,
+        # so this branch only fires for old templates.
         if "#SECRETS_BLOCK#" in ci_def:
             from wads.ci_secrets import render_stub_secrets_passthrough
 

--- a/wads/scripts/export_ci_env.py
+++ b/wads/scripts/export_ci_env.py
@@ -193,7 +193,8 @@ def export_ci_env(
     missing_test = []
     mask_values = []
 
-    # Literal defaults first, so a secret-backed var of the same name wins.
+    # Literal defaults first; a later secret-backed var of the same name is
+    # skipped as already-seen, so the committed default is authoritative.
     for key, value in defaults.items():
         assignments.append(_gh_env_assignment(str(key), str(value)))
         exported.append(str(key))
@@ -246,14 +247,23 @@ def export_ci_env(
     return ExportPlan(assignments, exported, missing_required, missing_test, mask_values)
 
 
-def _load_json_env(name: str, default):
+def _load_json_env(name: str, default, *, redact: bool = False):
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
     try:
         return json.loads(raw)
-    except json.JSONDecodeError:
-        print(f"[ERROR] {name} is not valid JSON: {raw!r}", file=sys.stderr)
+    except json.JSONDecodeError as e:
+        if redact:
+            # Never echo the raw value: the secrets/vars contexts arrive
+            # JSON-re-escaped, a form no registered mask matches.
+            print(
+                f"[ERROR] {name} is not valid JSON ({e}; length {len(raw)}); "
+                f"value withheld — it may contain secrets",
+                file=sys.stderr,
+            )
+        else:
+            print(f"[ERROR] {name} is not valid JSON: {raw!r}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -263,11 +273,17 @@ def _emit_masks(mask_values):
     Values pulled out of the transport blob are NOT auto-masked (GitHub only
     masks the blob itself), so every line of every value is registered
     explicitly. Harmlessly re-masks named-transport values.
+
+    The runner percent-decodes workflow-command data (``%25``→``%``,
+    ``%0A``→newline, ``%0D``→CR), so ``%`` must be escaped or a value
+    containing a literal ``%25``/``%0A`` would register the wrong mask string
+    and leave the real value unmasked (CR/LF are already handled by the
+    per-line split).
     """
     for value in mask_values:
         for line in value.splitlines():
             if line.strip():
-                print(f"::add-mask::{line}")
+                print(f"::add-mask::{line.replace('%', '%25')}")
 
 
 def main() -> int:
@@ -278,8 +294,8 @@ def main() -> int:
     extra = _load_json_env("WADS_ENV_EXTRA", [])
     defaults = _load_json_env("WADS_ENV_DEFAULTS", {})
     aliases = _load_json_env("WADS_ENV_ALIASES", {})
-    secrets = _load_json_env("WADS_SECRETS_JSON", {})
-    vars_ = _load_json_env("WADS_VARS_JSON", {})
+    secrets = _load_json_env("WADS_SECRETS_JSON", {}, redact=True)
+    vars_ = _load_json_env("WADS_VARS_JSON", {}, redact=True)
 
     plan = export_ci_env(
         required=list(required) + [n for n in always_required if n not in required],

--- a/wads/scripts/export_ci_env.py
+++ b/wads/scripts/export_ci_env.py
@@ -2,32 +2,49 @@
 """Export the pyproject-declared CI environment to ``$GITHUB_ENV``.
 
 This is the run-time half of wads' two-layer secret model (see
-:mod:`wads.ci_secrets`). The reusable workflow declares a static *superset* of
-secrets (transport); this script decides which of them actually become job
-environment variables, driven entirely by ``[tool.wads.ci.env]`` in the
-consumer's ``pyproject.toml`` (read via the ``read-ci-config`` action):
+:mod:`wads.ci_secrets`). The reusable workflow receives the caller's secrets
+either as named pass-throughs (legacy stubs) or as one double-encoded JSON
+blob under ``WADS_CI_SECRETS_JSON`` (modern stubs); this script decides which
+values actually become job environment variables, driven entirely by
+``[tool.wads.ci.env]`` in the consumer's ``pyproject.toml`` (read via the
+``read-ci-config`` action):
 
 * ``defaults``  — literal ``KEY=value`` pairs, always written.
-* ``required_envvars`` — must resolve to a non-empty secret, else CI **fails**
-  with a precise message.
+* ``required_envvars`` — must resolve non-empty, else CI **fails** with a
+  precise message.
 * ``test_envvars`` — exported if set; a **warning** is emitted if missing.
 * ``extra_envvars`` — exported if set; silent if missing.
 * ``secret_aliases`` — map ``ENV_VAR -> SECRET_NAME`` for the (rare) case where
   the env var the code reads differs from the GitHub secret name.
 
-The full ``secrets`` context is handed in as JSON via ``toJSON(secrets)`` so this
-logic needs **no per-secret enumeration** — only the workflow's static
-``on.workflow_call.secrets`` block enumerates (and that is generated from
-:data:`wads.ci_secrets.DEFAULT_CI_SECRETS`).
+Each declared name resolves against **secrets first** (named ones merged with
+the transport blob) and the caller's **repository variables second** (the
+``vars`` context resolves to the caller's repo in a reusable workflow) — so a
+non-sensitive value like a test verbosity level can live in a repo variable
+instead of being mis-classified as a secret.
 
-Secret *values* are never printed; only names appear in the summary. Values are
-GitHub-registered secrets and are masked in logs regardless.
+Secret *values* are never printed. Values extracted from the transport blob
+are not auto-masked by GitHub (only the blob as a whole is), so every
+secret-sourced value is re-registered with ``::add-mask::`` (per line, the
+documented form for multiline values) before being written to the job env.
 """
 
 import json
 import os
 import sys
-from pathlib import Path
+from typing import NamedTuple
+
+# The blob key is a wads-wide constant; keep this script importable standalone
+# (it is executed via `python -m` from a pip-installed wads) but don't crash if
+# the import graph ever changes — the name is stable.
+try:
+    from wads.ci_secrets import JSON_TRANSPORT_SECRET
+except ImportError:  # pragma: no cover - belt and braces for exotic installs
+    JSON_TRANSPORT_SECRET = "WADS_CI_SECRETS_JSON"
+
+# Secrets-context keys that must never be exported as repo env vars: GitHub's
+# auto-token (the context spells it `github_token`) and the transport blob.
+_NON_EXPORTABLE = frozenset({"github_token", JSON_TRANSPORT_SECRET.lower()})
 
 
 def _gh_env_assignment(name: str, value: str) -> str:
@@ -54,6 +71,64 @@ def _gh_env_assignment(name: str, value: str) -> str:
     return f"{name}<<{delimiter}\n{value}\n{delimiter}"
 
 
+def merge_transported_secrets(secrets):
+    """Flatten the secrets mapping, expanding the ``WADS_CI_SECRETS_JSON`` blob.
+
+    The blob is the caller's whole secrets context, serialized by the stub with
+    ``toJSON(toJSON(secrets))`` (double-encoded => single-line). A
+    single-encoded blob is also accepted. Named entries win over blob entries
+    (they are the same caller values anyway), and non-exportable keys (the
+    blob itself, ``github_token``) are dropped.
+
+    >>> merged = merge_transported_secrets({
+    ...     "WADS_CI_SECRETS_JSON": '"{\\\\n  \\\\"MY_KEY\\\\": \\\\"v1\\\\",\\\\n  \\\\"github_token\\\\": \\\\"t\\\\"\\\\n}"',
+    ...     "OPENAI_API_KEY": "sk-named",
+    ... })
+    >>> sorted(merged)
+    ['MY_KEY', 'OPENAI_API_KEY']
+    >>> merged["MY_KEY"]
+    'v1'
+
+    Malformed blobs are ignored rather than fatal (the named layer still
+    works, and required-validation reports any name that failed to resolve):
+
+    >>> merge_transported_secrets({"WADS_CI_SECRETS_JSON": "not json", "A": "x"})
+    {'A': 'x'}
+    """
+    secrets = dict(secrets or {})
+    blob = secrets.get(JSON_TRANSPORT_SECRET, "")
+    from_blob = {}
+    if blob:
+        try:
+            decoded = json.loads(blob)
+            if isinstance(decoded, str):  # double-encoded (the stub default)
+                decoded = json.loads(decoded)
+            if isinstance(decoded, dict):
+                from_blob = {str(k): str(v) for k, v in decoded.items()}
+        except (json.JSONDecodeError, TypeError):
+            print(
+                f"::warning::{JSON_TRANSPORT_SECRET} is not valid JSON; "
+                "ignoring the transport blob.",
+                file=sys.stderr,
+            )
+    merged = {**from_blob, **{k: v for k, v in secrets.items() if v}}
+    return {
+        name: value
+        for name, value in merged.items()
+        if value and name.lower() not in _NON_EXPORTABLE
+    }
+
+
+class ExportPlan(NamedTuple):
+    """What :func:`export_ci_env` decided, ready for :func:`main` to apply."""
+
+    assignments: list  # ordered $GITHUB_ENV lines
+    exported: list  # env-var names written, in order
+    missing_required: list  # (var_name, source_name) pairs that failed to resolve
+    missing_test: list  # test var names that failed to resolve
+    mask_values: list  # secret-sourced values to ::add-mask:: before export
+
+
 def export_ci_env(
     *,
     required=(),
@@ -62,54 +137,61 @@ def export_ci_env(
     defaults=None,
     aliases=None,
     secrets=None,
+    vars_=None,
     warn=lambda msg: print(msg, file=sys.stderr),
 ):
     """Compute the env assignments to write, plus any missing-required errors.
 
-    Pure function (no I/O) so it can be unit-tested without GitHub. Returns
-    ``(assignments, exported, missing_required, missing_test)`` where
-    ``assignments`` is an ordered list of ``$GITHUB_ENV`` lines.
+    Pure function (no I/O) so it can be unit-tested without GitHub. Each
+    declared name resolves secrets-first, then falls back to the caller's
+    repository variables (``vars_``). Secret-sourced values are collected in
+    ``mask_values`` for re-masking; variable- and default-sourced values are
+    not masked (they are not sensitive by definition).
 
-    >>> a, exported, missing_req, missing_test = export_ci_env(
+    >>> plan = export_ci_env(
     ...     required=["OPENAI_API_KEY"],
     ...     test=["TAVILY_API_KEY"],
-    ...     extra=["UNSET_THING"],
+    ...     extra=["UNSET_THING", "COSMO_TEST_LEVEL"],
     ...     defaults={"LOG_LEVEL": "DEBUG"},
     ...     secrets={"OPENAI_API_KEY": "sk-xxx", "TAVILY_API_KEY": ""},
+    ...     vars_={"COSMO_TEST_LEVEL": "3"},
     ... )
-    >>> exported
-    ['LOG_LEVEL', 'OPENAI_API_KEY']
-    >>> missing_req
+    >>> plan.exported
+    ['LOG_LEVEL', 'OPENAI_API_KEY', 'COSMO_TEST_LEVEL']
+    >>> plan.missing_required
     []
-    >>> missing_test
+    >>> plan.missing_test
     ['TAVILY_API_KEY']
+    >>> plan.mask_values  # only the secret-sourced value
+    ['sk-xxx']
 
-    A required var with no backing secret is reported (caller should fail CI):
+    A required var with no backing secret *or* variable is reported (caller
+    should fail CI):
 
-    >>> _, _, missing_req, _ = export_ci_env(
-    ...     required=["PYPI_PASSWORD"], secrets={})
-    >>> missing_req
+    >>> export_ci_env(required=["PYPI_PASSWORD"], secrets={}).missing_required
     [('PYPI_PASSWORD', 'PYPI_PASSWORD')]
 
     Aliases let an env var read a differently-named secret:
 
-    >>> a, exported, _, _ = export_ci_env(
+    >>> plan = export_ci_env(
     ...     test=["HF_TOKEN"],
     ...     aliases={"HF_TOKEN": "HF_WRITE_TOKEN"},
     ...     secrets={"HF_WRITE_TOKEN": "hf_xxx"})
-    >>> exported
+    >>> plan.exported
     ['HF_TOKEN']
-    >>> a
+    >>> plan.assignments
     ['HF_TOKEN=hf_xxx']
     """
     defaults = defaults or {}
     aliases = aliases or {}
-    secrets = secrets or {}
+    secrets = merge_transported_secrets(secrets)
+    vars_ = vars_ or {}
 
     assignments = []
     exported = []
     missing_required = []
     missing_test = []
+    mask_values = []
 
     # Literal defaults first, so a secret-backed var of the same name wins.
     for key, value in defaults.items():
@@ -117,45 +199,51 @@ def export_ci_env(
         exported.append(str(key))
 
     def _resolve(var_name):
-        secret_name = aliases.get(var_name, var_name)
-        return secret_name, secrets.get(secret_name) or ""
+        """Return ``(source_name, value, is_secret)`` for ``var_name``."""
+        source_name = aliases.get(var_name, var_name)
+        value = secrets.get(source_name) or ""
+        if value:
+            return source_name, value, True
+        return source_name, str(vars_.get(source_name) or ""), False
 
     seen = set(exported)
+
+    def _export(var_name, value, is_secret):
+        if var_name in seen:
+            return
+        if is_secret:
+            mask_values.append(value)
+        assignments.append(_gh_env_assignment(var_name, value))
+        exported.append(var_name)
+        seen.add(var_name)
+
     for var_name in required:
-        secret_name, value = _resolve(var_name)
+        source_name, value, is_secret = _resolve(var_name)
         if not value:
-            missing_required.append((var_name, secret_name))
+            missing_required.append((var_name, source_name))
             continue
-        if var_name not in seen:
-            assignments.append(_gh_env_assignment(var_name, value))
-            exported.append(var_name)
-            seen.add(var_name)
+        _export(var_name, value, is_secret)
 
     for var_name in test:
-        secret_name, value = _resolve(var_name)
+        _, value, is_secret = _resolve(var_name)
         if not value:
             missing_test.append(var_name)
             continue
-        if var_name not in seen:
-            assignments.append(_gh_env_assignment(var_name, value))
-            exported.append(var_name)
-            seen.add(var_name)
+        _export(var_name, value, is_secret)
 
     for var_name in extra:
-        _, value = _resolve(var_name)
-        if value and var_name not in seen:
-            assignments.append(_gh_env_assignment(var_name, value))
-            exported.append(var_name)
-            seen.add(var_name)
+        _, value, is_secret = _resolve(var_name)
+        if value:
+            _export(var_name, value, is_secret)
 
     for var_name in missing_test:
         warn(
             f"::warning::[tool.wads.ci.env].test_envvars lists {var_name!r} but "
-            f"its backing secret is not set on this repo; tests needing it may be "
-            f"skipped or fail."
+            f"no backing secret or repo variable is set; tests needing it may "
+            f"be skipped or fail."
         )
 
-    return assignments, exported, missing_required, missing_test
+    return ExportPlan(assignments, exported, missing_required, missing_test, mask_values)
 
 
 def _load_json_env(name: str, default):
@@ -169,48 +257,68 @@ def _load_json_env(name: str, default):
         sys.exit(1)
 
 
+def _emit_masks(mask_values):
+    """Register each secret-sourced value with the runner's log masker.
+
+    Values pulled out of the transport blob are NOT auto-masked (GitHub only
+    masks the blob itself), so every line of every value is registered
+    explicitly. Harmlessly re-masks named-transport values.
+    """
+    for value in mask_values:
+        for line in value.splitlines():
+            if line.strip():
+                print(f"::add-mask::{line}")
+
+
 def main() -> int:
     """Read inputs from env, write assignments to ``$GITHUB_ENV``, fail if required missing."""
     required = _load_json_env("WADS_ENV_REQUIRED", [])
+    always_required = _load_json_env("WADS_ENV_ALWAYS_REQUIRED", [])
     test = _load_json_env("WADS_ENV_TEST", [])
     extra = _load_json_env("WADS_ENV_EXTRA", [])
     defaults = _load_json_env("WADS_ENV_DEFAULTS", {})
     aliases = _load_json_env("WADS_ENV_ALIASES", {})
     secrets = _load_json_env("WADS_SECRETS_JSON", {})
+    vars_ = _load_json_env("WADS_VARS_JSON", {})
 
-    assignments, exported, missing_required, _ = export_ci_env(
-        required=required,
+    plan = export_ci_env(
+        required=list(required) + [n for n in always_required if n not in required],
         test=test,
         extra=extra,
         defaults=defaults,
         aliases=aliases,
         secrets=secrets,
+        vars_=vars_,
     )
+
+    # Masks must be registered before any later step could echo the values.
+    _emit_masks(plan.mask_values)
 
     github_env = os.environ.get("GITHUB_ENV")
     if github_env:
         with open(github_env, "a") as f:
-            for line in assignments:
+            for line in plan.assignments:
                 f.write(line + "\n")
     else:
         print("Warning: GITHUB_ENV not set; not writing assignments", file=sys.stderr)
 
-    if exported:
-        print(f"[OK] Exported CI env vars: {', '.join(exported)}")
+    if plan.exported:
+        print(f"[OK] Exported CI env vars: {', '.join(plan.exported)}")
     else:
         print("[OK] No CI env vars configured to export")
 
-    if missing_required:
+    if plan.missing_required:
         details = "\n".join(
-            f"  - env var {var!r} (backed by secret {sec!r}) is required by "
-            f"[tool.wads.ci.env].required_envvars but the secret is not set"
-            for var, sec in missing_required
+            f"  - env var {var!r} (backed by {src!r}) is required but neither a "
+            f"secret nor a repo variable of that name is set"
+            for var, src in plan.missing_required
         )
         print(
-            "[ERROR] Required CI secrets are missing:\n"
+            "[ERROR] Required CI values are missing:\n"
             f"{details}\n"
-            "Set them on the repo (e.g. `wads-secrets add NAME` or "
-            "`gh secret set NAME`), or move them out of required_envvars.",
+            "Set a secret (`wads-secrets add NAME` or `gh secret set NAME`), or "
+            "for non-sensitive values a repo variable (`gh variable set NAME`), "
+            "or move the name out of required_envvars.",
             file=sys.stderr,
         )
         return 1

--- a/wads/secrets_cli.py
+++ b/wads/secrets_cli.py
@@ -51,6 +51,12 @@ _KINDS = {
     "extra": "extra_envvars",
 }
 
+# The JSON transport *line* in a stub's `secrets:` block (an actual YAML key,
+# not a mention of the name in a comment).
+_JSON_TRANSPORT_LINE_RE = re.compile(
+    rf"(?m)^\s*{re.escape(JSON_TRANSPORT_SECRET)}\s*:"
+)
+
 
 def _err(msg: str):
     print(f"error: {msg}", file=sys.stderr)
@@ -136,18 +142,19 @@ def add_env_var_to_pyproject(pyproject_path, var_name, secret_name, *, kind="ext
 
 
 def stub_transport_mode(ci_file) -> "str | None":
-    """Classify the repo's ``ci.yml``: ``'json'``, ``'named'``, or ``None``.
+    """Classify the repo's ``ci.yml``: ``'json'``, ``'named'``, ``'inline'``, or ``None``.
 
-    ``None`` means there is no stub to speak of (missing file, or an inline
-    workflow — which reads repo secrets directly and has no transport layer).
+    ``'inline'`` means a workflow that does not call the reusable uv-ci (it
+    reads repo secrets directly and has no transport layer — and no
+    repo-variable fallback either). ``None`` means no ci.yml at all.
     """
     ci_file = Path(ci_file)
     if not ci_file.is_file():
         return None
     text = ci_file.read_text()
     if "uv-ci.yml" not in text:
-        return None
-    return "json" if JSON_TRANSPORT_SECRET in text else "named"
+        return "inline"
+    return "json" if _JSON_TRANSPORT_LINE_RE.search(text) else "named"
 
 
 def add_secret_to_stub(ci_file, secret_name):
@@ -165,7 +172,7 @@ def add_secret_to_stub(ci_file, secret_name):
             "ci.yml is not the wads reusable-workflow stub (inline workflow?); "
             "transport not edited — env is driven by [tool.wads.ci.env]"
         )
-    if JSON_TRANSPORT_SECRET in text:
+    if _JSON_TRANSPORT_LINE_RE.search(text):
         return False, (
             "stub uses the JSON transport — every repo secret is passed "
             "automatically; nothing to edit"
@@ -268,30 +275,37 @@ def add(
                 f"{_KINDS[kind]} — move it by hand if that's intended)"
             )
 
+    mode = stub_transport_mode(ci_file)
     if variable:
         # Repo variables reach the reusable workflow via the caller-resolved
         # `vars` context — no transport edit, no superset concern.
-        print("· transport: repo variables need none (vars context)")
+        if mode == "inline":
+            print(
+                "⚠ transport: this repo uses an inline workflow, which reads "
+                "secrets directly and has NO repo-variable fallback — a repo "
+                "variable will not reach its CI env. Use a committed literal "
+                "in [tool.wads.ci.env].defaults, or migrate to the stub "
+                "(`wads-migrate ci-to-stub`)."
+            )
+        else:
+            print("· transport: repo variables need none (vars context)")
+    elif mode == "named" and secret_name not in DEFAULT_CI_SECRETS:
+        # A named-transport stub may only pass names in the frozen superset —
+        # anything else makes the workflow FAIL TO START (parse-time
+        # startup_failure, issue #63). Refuse the edit that would cause it.
+        print(
+            f"⚠ transport: {secret_name!r} is not in the wads secret superset "
+            f"(wads/ci_secrets.py), and this repo's stub passes secrets by "
+            f"name — passing this one would make the workflow FAIL TO START, "
+            f"so ci.yml was NOT edited (declared in pyproject only). Either "
+            f"regenerate the stub with the JSON transport "
+            f"(`wads-migrate ci-to-stub`), which passes every secret; or, if "
+            f"the value is not sensitive, use "
+            f"`wads-secrets add {var_name} --variable` instead."
+        )
     else:
         stub_changed, reason = add_secret_to_stub(ci_file, secret_name)
         print(f"{'✓' if stub_changed else '·'} transport: {reason}")
-
-        # Only a legacy NAMED-transport stub is limited to the frozen
-        # superset; the JSON transport passes any name, and inline workflows
-        # read repo secrets directly.
-        if (
-            stub_transport_mode(ci_file) == "named"
-            and secret_name not in DEFAULT_CI_SECRETS
-        ):
-            print(
-                f"⚠ {secret_name!r} is not in the wads secret superset "
-                f"(wads/ci_secrets.py), and this repo's stub passes secrets "
-                f"by name — the workflow will FAIL TO START if it passes "
-                f"this one. Regenerate the stub with the JSON transport "
-                f"(`wads-migrate ci-to-stub`), which passes every secret; "
-                f"or, if the value is not sensitive, use "
-                f"`wads-secrets add {var_name} --variable` instead."
-            )
 
     if github:
         _maybe_set_github_value(

--- a/wads/secrets_cli.py
+++ b/wads/secrets_cli.py
@@ -1,22 +1,30 @@
 """``wads-secrets`` — manage the CI secrets/env vars of a wads-managed repo.
 
-A secret becomes usable in CI through two coordinated edits (see
-:mod:`wads.ci_secrets` for the model):
+A secret becomes usable in CI through two layers (see :mod:`wads.ci_secrets`
+for the model):
 
 1. **pyproject** ``[tool.wads.ci.env]`` — declares the env var (and whether it
    is required), so the reusable workflow exports it into the job environment.
-2. **stub transport** — the repo's ``ci.yml`` must *pass* the backing secret to
-   the reusable workflow (cross-owner ``secrets: inherit`` is unreliable).
+2. **transport** — the repo's ``ci.yml`` stub passes secrets to the reusable
+   workflow. Modern stubs pass the whole secrets context as one
+   ``WADS_CI_SECRETS_JSON`` secret, so *no per-secret stub edit is needed*;
+   legacy named-transport stubs list each secret explicitly (and every listed
+   name must be in the frozen wads superset).
 
-``wads-secrets add`` performs both edits in one step, and can also set the
-secret's value on GitHub via ``gh`` — so a single command takes a secret from
-"not configured" to "available in CI".
+``wads-secrets add`` performs the needed edits in one step, and can also set
+the secret's value on GitHub via ``gh`` — so a single command takes a secret
+from "not configured" to "available in CI". For values that are **not
+sensitive** (a test verbosity level, a feature flag), use ``--variable`` to
+store them as a GitHub repository *variable* instead of a secret — declared
+env vars fall back to repo variables automatically, and committed constants
+can simply live in ``[tool.wads.ci.env].defaults``.
 
 Examples::
 
     wads-secrets add OPENAI_API_KEY                 # var == secret name
     wads-secrets add HF_TOKEN HF_WRITE_TOKEN         # env var <- aliased secret
     wads-secrets add DB_URL --kind required          # fail CI if unset
+    wads-secrets add COSMO_TEST_LEVEL --variable     # non-sensitive: repo var
     wads-secrets add OPENAI_API_KEY --no-github      # edit files only
     wads-secrets list                                # show configured env vars
 
@@ -32,6 +40,7 @@ from pathlib import Path
 
 from wads.ci_secrets import (
     DEFAULT_CI_SECRETS,
+    JSON_TRANSPORT_SECRET,
     InvalidSecretName,
     normalize_secret_name,
 )
@@ -126,11 +135,26 @@ def add_env_var_to_pyproject(pyproject_path, var_name, secret_name, *, kind="ext
     return True, None
 
 
+def stub_transport_mode(ci_file) -> "str | None":
+    """Classify the repo's ``ci.yml``: ``'json'``, ``'named'``, or ``None``.
+
+    ``None`` means there is no stub to speak of (missing file, or an inline
+    workflow — which reads repo secrets directly and has no transport layer).
+    """
+    ci_file = Path(ci_file)
+    if not ci_file.is_file():
+        return None
+    text = ci_file.read_text()
+    if "uv-ci.yml" not in text:
+        return None
+    return "json" if JSON_TRANSPORT_SECRET in text else "named"
+
+
 def add_secret_to_stub(ci_file, secret_name):
     """Ensure the stub ``ci.yml`` passes ``secret_name`` to the reusable workflow.
 
-    Returns ``(changed, reason)``. ``reason`` explains no-ops (already present,
-    not a stub, file missing).
+    Returns ``(changed, reason)``. ``reason`` explains no-ops (JSON transport
+    passes everything already, already present, not a stub, file missing).
     """
     ci_file = Path(ci_file)
     if not ci_file.is_file():
@@ -140,6 +164,11 @@ def add_secret_to_stub(ci_file, secret_name):
         return False, (
             "ci.yml is not the wads reusable-workflow stub (inline workflow?); "
             "transport not edited — env is driven by [tool.wads.ci.env]"
+        )
+    if JSON_TRANSPORT_SECRET in text:
+        return False, (
+            "stub uses the JSON transport — every repo secret is passed "
+            "automatically; nothing to edit"
         )
     if re.search(rf"secrets\.{re.escape(secret_name)}\b", text):
         return False, "already passed in ci.yml"
@@ -168,16 +197,17 @@ def _gh_available() -> bool:
         return False
 
 
-def set_github_secret(repo, secret_name, value) -> bool:
-    """Set ``secret_name`` on ``repo`` via ``gh secret set``. Returns success."""
+def set_github_secret(repo, secret_name, value, *, variable=False) -> bool:
+    """Set a secret (or, with ``variable=True``, a repo variable) via ``gh``."""
+    kind = "variable" if variable else "secret"
     try:
         subprocess.run(
-            ["gh", "secret", "set", secret_name, "--repo", repo, "--body", value],
+            ["gh", kind, "set", secret_name, "--repo", repo, "--body", value],
             check=True,
         )
         return True
     except subprocess.CalledProcessError as e:
-        _err(f"gh secret set failed: {e}")
+        _err(f"gh {kind} set failed: {e}")
         return False
 
 
@@ -189,10 +219,11 @@ def add(
     kind="extra",
     value=None,
     github=True,
+    variable=False,
     pyproject="pyproject.toml",
     ci_file=".github/workflows/ci.yml",
 ):
-    """Configure a CI secret: declare it in pyproject, pass it in ci.yml, set its value.
+    """Configure a CI value: declare it in pyproject, transport it, set its value.
 
     :param var_name: env-var name your code reads (forced to UPPER_SNAKE).
     :param secret_name: GitHub secret backing it (default: same as var_name).
@@ -200,6 +231,10 @@ def add(
     :param kind: ``extra`` (default), ``test``, or ``required``.
     :param value: secret value to push to GitHub (default: ``$VAR_NAME`` in env).
     :param github: also set the value on GitHub via ``gh`` (default True).
+    :param variable: store as a repository *variable* instead of a secret —
+        for non-sensitive values (a test verbosity level, a flag). Variables
+        need no transport at all: the reusable workflow reads the caller's
+        ``vars`` context directly and declared env vars fall back to it.
     """
     try:
         var_name = normalize_secret_name(var_name)
@@ -233,27 +268,44 @@ def add(
                 f"{_KINDS[kind]} — move it by hand if that's intended)"
             )
 
-    stub_changed, reason = add_secret_to_stub(ci_file, secret_name)
-    print(f"{'✓' if stub_changed else '·'} transport: {reason}")
+    if variable:
+        # Repo variables reach the reusable workflow via the caller-resolved
+        # `vars` context — no transport edit, no superset concern.
+        print("· transport: repo variables need none (vars context)")
+    else:
+        stub_changed, reason = add_secret_to_stub(ci_file, secret_name)
+        print(f"{'✓' if stub_changed else '·'} transport: {reason}")
 
-    if secret_name not in DEFAULT_CI_SECRETS:
-        print(
-            f"⚠ {secret_name!r} is not in the wads secret superset "
-            f"(wads/ci_secrets.py). The reusable workflow will reject an "
-            f"undeclared secret. Add it to DEFAULT_CI_SECRETS via a wads PR, or "
-            f"use the inline-workflow escape valve."
-        )
+        # Only a legacy NAMED-transport stub is limited to the frozen
+        # superset; the JSON transport passes any name, and inline workflows
+        # read repo secrets directly.
+        if (
+            stub_transport_mode(ci_file) == "named"
+            and secret_name not in DEFAULT_CI_SECRETS
+        ):
+            print(
+                f"⚠ {secret_name!r} is not in the wads secret superset "
+                f"(wads/ci_secrets.py), and this repo's stub passes secrets "
+                f"by name — the workflow will FAIL TO START if it passes "
+                f"this one. Regenerate the stub with the JSON transport "
+                f"(`wads-migrate ci-to-stub`), which passes every secret; "
+                f"or, if the value is not sensitive, use "
+                f"`wads-secrets add {var_name} --variable` instead."
+            )
 
     if github:
-        _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file)
+        _maybe_set_github_value(
+            repo, secret_name, var_name, value, ci_file, variable=variable
+        )
     return 0
 
 
-def _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file):
+def _maybe_set_github_value(repo, secret_name, var_name, value, ci_file, *, variable=False):
+    kind = "variable" if variable else "secret"
     if not _gh_available():
         print(
             f"· github: `gh` not found; set it manually:\n"
-            f"    gh secret set {secret_name} --repo <org/repo>"
+            f"    gh {kind} set {secret_name} --repo <org/repo>"
         )
         return
     repo = repo or _repo_from_git(
@@ -262,7 +314,7 @@ def _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file):
     if not repo:
         print(
             f"· github: could not detect repo (no git origin); set it manually:\n"
-            f"    gh secret set {secret_name} --repo <org/repo>"
+            f"    gh {kind} set {secret_name} --repo <org/repo>"
         )
         return
     if value is None:
@@ -271,11 +323,11 @@ def _maybe_set_github_secret(repo, secret_name, var_name, value, ci_file):
         print(
             f"· github: no value for {secret_name!r} (pass --value or export "
             f"${var_name}); set it later with:\n"
-            f"    gh secret set {secret_name} --repo {repo}"
+            f"    gh {kind} set {secret_name} --repo {repo}"
         )
         return
-    if set_github_secret(repo, secret_name, value):
-        print(f"✓ github: set secret {secret_name!r} on {repo}")
+    if set_github_secret(repo, secret_name, value, variable=variable):
+        print(f"✓ github: set {kind} {secret_name!r} on {repo}")
 
 
 def list_(pyproject="pyproject.toml"):
@@ -355,6 +407,14 @@ def main(argv=None):
         action="store_false",
         help="edit files only; don't call gh",
     )
+    p_add.add_argument(
+        "--variable",
+        action="store_true",
+        help=(
+            "store as a repository VARIABLE instead of a secret — for "
+            "non-sensitive values; needs no transport and no masking"
+        ),
+    )
     p_add.add_argument("--pyproject", default="pyproject.toml")
     p_add.add_argument("--ci-file", dest="ci_file", default=".github/workflows/ci.yml")
 
@@ -372,6 +432,7 @@ def main(argv=None):
             kind=args.kind,
             value=args.value,
             github=args.github,
+            variable=args.variable,
             pyproject=args.pyproject,
             ci_file=args.ci_file,
         )

--- a/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
+++ b/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
@@ -29,20 +29,19 @@ jobs:
     permissions:
       contents: write
       pages: write
-    # Explicit pass-through (not `secrets: inherit`) because `inherit` does
-    # not reliably propagate caller-repo secrets to a reusable workflow owned
-    # by a different account (verified empirically: personal-account caller +
-    # i2mint-org workflow → `${{ secrets.PYPI_PASSWORD }}` resolved to empty).
+    # Transport: this repo's whole `secrets` context, serialized into the one
+    # secret the reusable workflow declares. Double-encoded (toJSON twice) so
+    # the value is a single line — a multiline secret would register its `{`
+    # and `}` lines as global log masks. Any secret name works; there is no
+    # fixed list to fall outside of. (Cross-owner `secrets: inherit` does not
+    # propagate secrets, so it cannot replace this.)
     #
-    # This list is the per-repo *transport*: it should contain PYPI_PASSWORD
-    # (for publishing) plus every secret your tests/CI need. It is generated
-    # from [tool.wads.ci.env] in pyproject.toml. To add one, run
-    #   wads-secrets add VAR_NAME            # updates pyproject + this block
-    # or just append a line below. *Which* of these become job env vars (and
-    # which are required) is controlled by [tool.wads.ci.env] — passing a
-    # secret here does not by itself put it in the environment.
-    #
-    # A secret name must also be declared in the reusable workflow's superset
-    # (wads/ci_secrets.py). `wads-secrets add` warns if it is not.
+    # *Which* of these become job env vars — and which are required — is
+    # driven entirely by [tool.wads.ci.env] in pyproject.toml; nothing is
+    # exported unless declared there (`wads-secrets add VAR_NAME` declares
+    # one and can set its value). Non-sensitive values don't need a secret:
+    # use [tool.wads.ci.env].defaults (committed literals) or a repository
+    # *variable* (`gh variable set NAME`) — declared names fall back to
+    # repo variables automatically.
     secrets:
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}

--- a/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
+++ b/wads/tests/data/golden/python_lib/.github/workflows/ci.yml
@@ -5,7 +5,11 @@
 # full inline template `wads/data/github_ci_uv.yml` from i2mint/wads.
 #
 # Pinning: `@master` floats with wads. If you need version stability for
-# a release-sensitive repo, change `@master` to a wads tag (e.g. `@v0.1.81`).
+# a release-sensitive repo, change `@master` to a wads tag (e.g. `@0.2.15`;
+# tags have no `v` prefix). A stub whose `secrets:` block passes the JSON
+# transport (the default below) needs a tag from a release after 0.2.14 —
+# older tags don't declare that secret and GitHub then rejects the
+# workflow at parse time.
 # CI failure does not block a published release — it blocks the publish
 # step itself — so floating master is generally safe.
 #
@@ -35,6 +39,11 @@ jobs:
     # and `}` lines as global log masks. Any secret name works; there is no
     # fixed list to fall outside of. (Cross-owner `secrets: inherit` does not
     # propagate secrets, so it cannot replace this.)
+    #
+    # Note this hands EVERY secret this repo can read — including org-level
+    # ones — to the called workflow. For a minimal secret surface (only the
+    # names you list), regenerate with
+    #   wads-migrate ci-to-stub --transport named
     #
     # *Which* of these become job env vars — and which are required — is
     # driven entirely by [tool.wads.ci.env] in pyproject.toml; nothing is

--- a/wads/tests/test_ci_secrets.py
+++ b/wads/tests/test_ci_secrets.py
@@ -13,9 +13,12 @@ import yaml
 
 from wads.ci_secrets import (
     DEFAULT_CI_SECRETS,
+    JSON_TRANSPORT_SECRET,
+    WORKFLOW_CALL_SECRETS,
     InvalidSecretName,
     is_valid_secret_name,
     normalize_secret_name,
+    render_stub_json_transport,
     render_stub_secrets_passthrough,
     render_workflow_call_secrets,
 )
@@ -59,13 +62,19 @@ def _secrets_from_workflow(path: Path):
 
 
 def test_uv_ci_secrets_match_ssot_exactly():
-    """The reusable workflow's secret superset must equal DEFAULT_CI_SECRETS.
+    """The reusable workflow's declared secrets must equal WORKFLOW_CALL_SECRETS.
 
+    That is the JSON transport secret first, then the frozen legacy superset.
     If this fails, you edited one side only. Regenerate the YAML block from
-    wads.ci_secrets.render_workflow_call_secrets() (or update DEFAULT_CI_SECRETS).
+    wads.ci_secrets.render_workflow_call_secrets().
     """
     declared = _secrets_from_workflow(UV_CI)
-    assert declared == list(DEFAULT_CI_SECRETS)
+    assert declared == list(WORKFLOW_CALL_SECRETS)
+
+
+def test_workflow_call_secrets_is_json_transport_plus_superset():
+    assert WORKFLOW_CALL_SECRETS[0] == JSON_TRANSPORT_SECRET
+    assert WORKFLOW_CALL_SECRETS[1:] == DEFAULT_CI_SECRETS
 
 
 def test_rendered_workflow_block_roundtrips():
@@ -74,7 +83,7 @@ def test_rendered_workflow_block_roundtrips():
     fake = "on:\n  workflow_call:\n    secrets:\n" + block + "\n"
     parsed = yaml.safe_load(fake)
     on = parsed.get("on", parsed.get(True))
-    assert list(on["workflow_call"]["secrets"].keys()) == list(DEFAULT_CI_SECRETS)
+    assert list(on["workflow_call"]["secrets"].keys()) == list(WORKFLOW_CALL_SECRETS)
 
 
 def test_stub_passthrough_render():
@@ -83,3 +92,15 @@ def test_stub_passthrough_render():
         "      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}\n"
         "      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}"
     )
+
+
+def test_stub_json_transport_render_matches_stub_template():
+    """The stub template must carry exactly the rendered JSON-transport line.
+
+    migrate_ci_to_stub's named mode locates this line in the template to
+    replace it, so renderer and template may not drift.
+    """
+    line = render_stub_json_transport()
+    assert line == "      WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}"
+    stub_tpl = REPO_ROOT / "wads" / "data" / "github_ci_uv_stub.yml"
+    assert line in stub_tpl.read_text()

--- a/wads/tests/test_export_ci_env.py
+++ b/wads/tests/test_export_ci_env.py
@@ -1,10 +1,16 @@
 """Tests for the run-time env-export logic (``wads.scripts.export_ci_env``)."""
 
-from wads.scripts.export_ci_env import _gh_env_assignment, export_ci_env
+import json
+
+from wads.scripts.export_ci_env import (
+    _gh_env_assignment,
+    export_ci_env,
+    merge_transported_secrets,
+)
 
 
 def test_exports_only_configured_and_set():
-    assignments, exported, missing_req, missing_test = export_ci_env(
+    plan = export_ci_env(
         required=["OPENAI_API_KEY"],
         test=["TAVILY_API_KEY"],
         extra=["UNSET_THING"],
@@ -12,32 +18,32 @@ def test_exports_only_configured_and_set():
         secrets={"OPENAI_API_KEY": "sk-x", "TAVILY_API_KEY": "", "OTHER": "y"},
         warn=lambda m: None,
     )
-    assert exported == ["LOG_LEVEL", "OPENAI_API_KEY"]
-    assert "OTHER" not in exported  # passed but not declared -> not exported
-    assert missing_req == []
-    assert missing_test == ["TAVILY_API_KEY"]
-    assert "LOG_LEVEL=DEBUG" in assignments
-    assert "OPENAI_API_KEY=sk-x" in assignments
+    assert plan.exported == ["LOG_LEVEL", "OPENAI_API_KEY"]
+    assert "OTHER" not in plan.exported  # passed but not declared -> not exported
+    assert plan.missing_required == []
+    assert plan.missing_test == ["TAVILY_API_KEY"]
+    assert "LOG_LEVEL=DEBUG" in plan.assignments
+    assert "OPENAI_API_KEY=sk-x" in plan.assignments
 
 
 def test_required_missing_is_reported():
-    _, _, missing_req, _ = export_ci_env(required=["PYPI_PASSWORD"], secrets={})
-    assert missing_req == [("PYPI_PASSWORD", "PYPI_PASSWORD")]
+    plan = export_ci_env(required=["PYPI_PASSWORD"], secrets={})
+    assert plan.missing_required == [("PYPI_PASSWORD", "PYPI_PASSWORD")]
 
 
 def test_alias_resolution():
-    assignments, exported, _, _ = export_ci_env(
+    plan = export_ci_env(
         test=["HF_TOKEN"],
         aliases={"HF_TOKEN": "HF_WRITE_TOKEN"},
         secrets={"HF_WRITE_TOKEN": "hf_x"},
         warn=lambda m: None,
     )
-    assert exported == ["HF_TOKEN"]
-    assert assignments == ["HF_TOKEN=hf_x"]
+    assert plan.exported == ["HF_TOKEN"]
+    assert plan.assignments == ["HF_TOKEN=hf_x"]
 
 
 def test_secret_overrides_default_of_same_name():
-    assignments, exported, _, _ = export_ci_env(
+    plan = export_ci_env(
         extra=["TOKEN"],
         defaults={"TOKEN": "literal"},
         secrets={"TOKEN": "from-secret"},
@@ -45,8 +51,8 @@ def test_secret_overrides_default_of_same_name():
     )
     # default written first, secret-backed var of same name skipped (already seen),
     # so the literal default stands — defaults are authoritative when both exist.
-    assert exported == ["TOKEN"]
-    assert assignments == ["TOKEN=literal"]
+    assert plan.exported == ["TOKEN"]
+    assert plan.assignments == ["TOKEN=literal"]
 
 
 def test_multiline_value_uses_heredoc():
@@ -59,3 +65,157 @@ def test_multiline_value_uses_heredoc():
 
 def test_single_line_value_plain():
     assert _gh_env_assignment("A", "b") == "A=b"
+
+
+# ---------------------------------------------------------------------------
+# JSON transport blob (WADS_CI_SECRETS_JSON) — issue #63
+# ---------------------------------------------------------------------------
+
+CALLER_SECRETS = {
+    "OPENAI_API_KEY": "sk-blob",
+    "COSMO_TEST_LEVEL": "3",  # deliberately outside the legacy superset
+    "github_token": "ghs_x",
+}
+
+
+def _blob(double_encoded=True):
+    """The transported value as GitHub produces it from toJSON (2-space indent)."""
+    once = json.dumps(CALLER_SECRETS, indent=2)
+    return json.dumps(once) if double_encoded else once
+
+
+def test_merge_expands_double_encoded_blob():
+    merged = merge_transported_secrets({"WADS_CI_SECRETS_JSON": _blob()})
+    assert merged == {"OPENAI_API_KEY": "sk-blob", "COSMO_TEST_LEVEL": "3"}
+
+
+def test_merge_expands_single_encoded_blob():
+    merged = merge_transported_secrets(
+        {"WADS_CI_SECRETS_JSON": _blob(double_encoded=False)}
+    )
+    assert merged["COSMO_TEST_LEVEL"] == "3"
+
+
+def test_merge_named_secret_wins_and_infra_keys_dropped():
+    merged = merge_transported_secrets(
+        {"WADS_CI_SECRETS_JSON": _blob(), "OPENAI_API_KEY": "sk-named"}
+    )
+    assert merged["OPENAI_API_KEY"] == "sk-named"
+    assert "github_token" not in merged
+    assert "WADS_CI_SECRETS_JSON" not in merged
+
+
+def test_merge_tolerates_malformed_blob():
+    merged = merge_transported_secrets(
+        {"WADS_CI_SECRETS_JSON": "not json", "A": "x"}
+    )
+    assert merged == {"A": "x"}
+
+
+def test_blob_sourced_values_are_export_equivalent_to_named():
+    """An out-of-superset name transported via the blob exports normally."""
+    plan = export_ci_env(
+        extra=["COSMO_TEST_LEVEL"],
+        secrets={"WADS_CI_SECRETS_JSON": _blob()},
+        warn=lambda m: None,
+    )
+    assert plan.exported == ["COSMO_TEST_LEVEL"]
+    assert plan.assignments == ["COSMO_TEST_LEVEL=3"]
+
+
+def test_blob_sourced_values_are_masked():
+    plan = export_ci_env(
+        extra=["OPENAI_API_KEY"],
+        defaults={"LOG_LEVEL": "DEBUG"},
+        secrets={"WADS_CI_SECRETS_JSON": _blob()},
+        warn=lambda m: None,
+    )
+    # secret-sourced values are re-masked; literal defaults are not.
+    assert plan.mask_values == ["sk-blob"]
+
+
+# ---------------------------------------------------------------------------
+# Repo-variable fallback (vars context)
+# ---------------------------------------------------------------------------
+
+
+def test_vars_fallback_for_non_secret_values():
+    plan = export_ci_env(
+        extra=["COSMO_TEST_LEVEL"],
+        secrets={},
+        vars_={"COSMO_TEST_LEVEL": "3"},
+        warn=lambda m: None,
+    )
+    assert plan.assignments == ["COSMO_TEST_LEVEL=3"]
+    assert plan.mask_values == []  # variables are not sensitive -> no mask
+
+
+def test_secret_beats_variable_of_same_name():
+    plan = export_ci_env(
+        extra=["X"],
+        secrets={"X": "from-secret"},
+        vars_={"X": "from-var"},
+        warn=lambda m: None,
+    )
+    assert plan.assignments == ["X=from-secret"]
+    assert plan.mask_values == ["from-secret"]
+
+
+def test_required_satisfied_by_variable():
+    plan = export_ci_env(
+        required=["COSMO_TEST_LEVEL"],
+        vars_={"COSMO_TEST_LEVEL": "3"},
+        warn=lambda m: None,
+    )
+    assert plan.missing_required == []
+    assert plan.exported == ["COSMO_TEST_LEVEL"]
+
+
+def test_alias_applies_to_variable_lookup():
+    plan = export_ci_env(
+        extra=["VERBOSITY"],
+        aliases={"VERBOSITY": "COSMO_TEST_LEVEL"},
+        vars_={"COSMO_TEST_LEVEL": "3"},
+        warn=lambda m: None,
+    )
+    assert plan.assignments == ["VERBOSITY=3"]
+
+
+# ---------------------------------------------------------------------------
+# main(): always-required merge + mask emission + GITHUB_ENV writing
+# ---------------------------------------------------------------------------
+
+
+def test_main_always_required_and_masks(tmp_path, monkeypatch, capsys):
+    from wads.scripts import export_ci_env as mod
+
+    gh_env = tmp_path / "github_env"
+    monkeypatch.setenv("GITHUB_ENV", str(gh_env))
+    monkeypatch.setenv("WADS_ENV_ALWAYS_REQUIRED", '["PYPI_PASSWORD"]')
+    monkeypatch.setenv(
+        "WADS_SECRETS_JSON",
+        json.dumps({"WADS_CI_SECRETS_JSON": json.dumps(json.dumps(
+            {"PYPI_PASSWORD": "pypi-tok", "github_token": "t"}, indent=2))}),
+    )
+    for unset in ("WADS_ENV_REQUIRED", "WADS_ENV_TEST", "WADS_ENV_EXTRA",
+                  "WADS_ENV_DEFAULTS", "WADS_ENV_ALIASES", "WADS_VARS_JSON"):
+        monkeypatch.delenv(unset, raising=False)
+
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "::add-mask::pypi-tok" in out
+    assert "PYPI_PASSWORD=pypi-tok" in gh_env.read_text()
+
+
+def test_main_fails_on_missing_always_required(tmp_path, monkeypatch, capsys):
+    from wads.scripts import export_ci_env as mod
+
+    monkeypatch.setenv("GITHUB_ENV", str(tmp_path / "github_env"))
+    monkeypatch.setenv("WADS_ENV_ALWAYS_REQUIRED", '["PYPI_PASSWORD"]')
+    monkeypatch.setenv("WADS_SECRETS_JSON", "{}")
+    for unset in ("WADS_ENV_REQUIRED", "WADS_ENV_TEST", "WADS_ENV_EXTRA",
+                  "WADS_ENV_DEFAULTS", "WADS_ENV_ALIASES", "WADS_VARS_JSON"):
+        monkeypatch.delenv(unset, raising=False)
+
+    assert mod.main() == 1
+    assert "PYPI_PASSWORD" in capsys.readouterr().err

--- a/wads/tests/test_export_ci_env.py
+++ b/wads/tests/test_export_ci_env.py
@@ -207,6 +207,42 @@ def test_main_always_required_and_masks(tmp_path, monkeypatch, capsys):
     assert "PYPI_PASSWORD=pypi-tok" in gh_env.read_text()
 
 
+def test_masks_percent_escape(tmp_path, monkeypatch, capsys):
+    """A value containing literal %25/%0A must register the percent-ESCAPED
+    mask, or the runner's percent-decoding registers the wrong string and the
+    real value stays unmasked (reviewer finding F3)."""
+    from wads.scripts import export_ci_env as mod
+
+    monkeypatch.setenv("GITHUB_ENV", str(tmp_path / "github_env"))
+    monkeypatch.setenv("WADS_ENV_EXTRA", '["DATABASE_URL"]')
+    monkeypatch.setenv(
+        "WADS_SECRETS_JSON",
+        json.dumps({"DATABASE_URL": "postgres://u:p%25w@host/db"}),
+    )
+    for unset in ("WADS_ENV_REQUIRED", "WADS_ENV_ALWAYS_REQUIRED", "WADS_ENV_TEST",
+                  "WADS_ENV_DEFAULTS", "WADS_ENV_ALIASES", "WADS_VARS_JSON"):
+        monkeypatch.delenv(unset, raising=False)
+
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "::add-mask::postgres://u:p%2525w@host/db" in out
+
+
+def test_malformed_secrets_json_is_redacted(tmp_path, monkeypatch, capsys):
+    """A parse failure of the secrets context must never echo the raw value."""
+    import pytest
+
+    from wads.scripts import export_ci_env as mod
+
+    monkeypatch.setenv("GITHUB_ENV", str(tmp_path / "github_env"))
+    monkeypatch.setenv("WADS_SECRETS_JSON", '{"SECRET_VALUE": "sk-leakme"')  # truncated
+    with pytest.raises(SystemExit):
+        mod.main()
+    err = capsys.readouterr().err
+    assert "sk-leakme" not in err
+    assert "withheld" in err
+
+
 def test_main_fails_on_missing_always_required(tmp_path, monkeypatch, capsys):
     from wads.scripts import export_ci_env as mod
 

--- a/wads/tests/test_secrets_cli.py
+++ b/wads/tests/test_secrets_cli.py
@@ -8,6 +8,7 @@ from wads.secrets_cli import (
     add_env_var_to_pyproject,
     add_secret_to_stub,
     list_,
+    stub_transport_mode,
     _repo_from_git,
 )
 
@@ -23,13 +24,24 @@ defaults = {}
 """
 
 
-@pytest.fixture
-def repo(tmp_path):
+def _make_repo(tmp_path, stub_text):
     (tmp_path / "pyproject.toml").write_text(PYPROJECT)
     wf = tmp_path / ".github" / "workflows"
     wf.mkdir(parents=True)
-    (wf / "ci.yml").write_text(migrate_ci_to_stub())
+    (wf / "ci.yml").write_text(stub_text)
     return tmp_path
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo with the default (JSON-transport) stub."""
+    return _make_repo(tmp_path, migrate_ci_to_stub())
+
+
+@pytest.fixture
+def named_repo(tmp_path):
+    """A repo with a legacy named-transport stub."""
+    return _make_repo(tmp_path, migrate_ci_to_stub(transport="named"))
 
 
 def test_add_env_var_and_alias(repo):
@@ -54,8 +66,19 @@ def test_add_env_var_idempotent(repo):
     assert existing == "extra_envvars"
 
 
-def test_add_secret_to_stub_inserts_once(repo):
+def test_json_stub_needs_no_transport_edit(repo):
+    """The default stub transports everything; add_secret_to_stub is a no-op."""
     ci = repo / ".github" / "workflows" / "ci.yml"
+    assert stub_transport_mode(ci) == "json"
+    before = ci.read_text()
+    changed, reason = add_secret_to_stub(ci, "OPENAI_API_KEY")
+    assert not changed and "JSON transport" in reason
+    assert ci.read_text() == before  # untouched
+
+
+def test_add_secret_to_stub_inserts_once(named_repo):
+    ci = named_repo / ".github" / "workflows" / "ci.yml"
+    assert stub_transport_mode(ci) == "named"
     changed, _ = add_secret_to_stub(ci, "OPENAI_API_KEY")
     assert changed
     assert "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}" in ci.read_text()
@@ -81,15 +104,16 @@ def test_list_reports_configured(repo, capsys):
     assert "HF_TOKEN" in out and "HF_WRITE_TOKEN" in out
 
 
-def test_add_does_not_short_circuit_when_already_declared(repo):
+def test_add_does_not_short_circuit_when_already_declared(named_repo):
     """Regression: a var already in pyproject must still get the ci.yml transport.
 
     Previously ``add`` returned early on an existing declaration, skipping both
     the transport edit and the GitHub secret set — so a half-configured secret
     (declared but not passed in ci.yml) could never be completed by re-running.
+    (Named-transport stub: the JSON stub has no per-secret transport at all.)
     """
-    pp = repo / "pyproject.toml"
-    ci = repo / ".github" / "workflows" / "ci.yml"
+    pp = named_repo / "pyproject.toml"
+    ci = named_repo / ".github" / "workflows" / "ci.yml"
     # Pre-declare in pyproject only; ci.yml does NOT yet pass it.
     add_env_var_to_pyproject(pp, "OPENAI_API_KEY", "OPENAI_API_KEY", kind="test")
     assert "secrets.OPENAI_API_KEY" not in ci.read_text()
@@ -106,14 +130,72 @@ def test_add_does_not_short_circuit_when_already_declared(repo):
     assert "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}" in ci.read_text()
 
 
-def test_add_is_idempotent_when_fully_configured(repo):
+def test_add_is_idempotent_when_fully_configured(named_repo):
     """Running ``add`` twice is a clean no-op (exit 0, single transport line)."""
-    pp = repo / "pyproject.toml"
-    ci = repo / ".github" / "workflows" / "ci.yml"
+    pp = named_repo / "pyproject.toml"
+    ci = named_repo / ".github" / "workflows" / "ci.yml"
     common = dict(kind="test", github=False, pyproject=str(pp), ci_file=str(ci))
     assert add("OPENAI_API_KEY", **common) == 0
     assert add("OPENAI_API_KEY", **common) == 0
     assert ci.read_text().count("secrets.OPENAI_API_KEY") == 1
+
+
+def test_add_on_json_stub_declares_without_stub_edit(repo, capsys):
+    """On a JSON-transport stub, `add` edits pyproject only — and any secret
+    name is fine (no superset warning, even for out-of-superset names)."""
+    pp = repo / "pyproject.toml"
+    ci = repo / ".github" / "workflows" / "ci.yml"
+    before = ci.read_text()
+    rc = add(
+        "COSMO_TEST_LEVEL",  # not in the legacy superset
+        kind="extra",
+        github=False,
+        pyproject=str(pp),
+        ci_file=str(ci),
+    )
+    assert rc == 0
+    assert ci.read_text() == before
+    out = capsys.readouterr().out
+    assert "COSMO_TEST_LEVEL" in pp.read_text()
+    assert "superset" not in out  # no scary warning on the JSON transport
+
+
+def test_add_on_named_stub_warns_outside_superset(named_repo, capsys):
+    """Issue #63: a named-transport stub passing an out-of-superset secret
+    cannot start; `add` must say so loudly."""
+    pp = named_repo / "pyproject.toml"
+    ci = named_repo / ".github" / "workflows" / "ci.yml"
+    rc = add(
+        "COSMO_TEST_LEVEL",
+        kind="extra",
+        github=False,
+        pyproject=str(pp),
+        ci_file=str(ci),
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "superset" in out and "FAIL TO START" in out
+    assert "--variable" in out  # points at the non-sensitive-value remedy
+
+
+def test_add_variable_skips_transport_and_superset(repo, capsys):
+    """--variable: pyproject declaration only; repo vars need no transport."""
+    pp = repo / "pyproject.toml"
+    ci = repo / ".github" / "workflows" / "ci.yml"
+    before = ci.read_text()
+    rc = add(
+        "COSMO_TEST_LEVEL",
+        kind="extra",
+        github=False,
+        variable=True,
+        pyproject=str(pp),
+        ci_file=str(ci),
+    )
+    assert rc == 0
+    assert ci.read_text() == before
+    assert "COSMO_TEST_LEVEL" in pp.read_text()
+    out = capsys.readouterr().out
+    assert "vars context" in out
 
 
 def test_repo_from_git_parses_urls(tmp_path, monkeypatch):

--- a/wads/tests/test_secrets_cli.py
+++ b/wads/tests/test_secrets_cli.py
@@ -160,11 +160,13 @@ def test_add_on_json_stub_declares_without_stub_edit(repo, capsys):
     assert "superset" not in out  # no scary warning on the JSON transport
 
 
-def test_add_on_named_stub_warns_outside_superset(named_repo, capsys):
+def test_add_on_named_stub_refuses_outside_superset_edit(named_repo, capsys):
     """Issue #63: a named-transport stub passing an out-of-superset secret
-    cannot start; `add` must say so loudly."""
+    cannot start — `add` must REFUSE the stub edit, not create the broken
+    state and then warn about it."""
     pp = named_repo / "pyproject.toml"
     ci = named_repo / ".github" / "workflows" / "ci.yml"
+    before = ci.read_text()
     rc = add(
         "COSMO_TEST_LEVEL",
         kind="extra",
@@ -173,9 +175,28 @@ def test_add_on_named_stub_warns_outside_superset(named_repo, capsys):
         ci_file=str(ci),
     )
     assert rc == 0
+    assert ci.read_text() == before  # the breaking edit must NOT happen
+    assert "COSMO_TEST_LEVEL" in pp.read_text()  # declaration still recorded
     out = capsys.readouterr().out
-    assert "superset" in out and "FAIL TO START" in out
+    assert "superset" in out and "FAIL TO START" in out and "NOT edited" in out
     assert "--variable" in out  # points at the non-sensitive-value remedy
+
+
+def test_add_variable_on_inline_workflow_warns(tmp_path, capsys):
+    """--variable on an inline workflow must warn: inline env blocks read
+    secrets only, so a repo variable would silently never arrive."""
+    tmp = _make_repo(tmp_path, "name: CI\non: [push]\njobs: {}\n")
+    rc = add(
+        "COSMO_TEST_LEVEL",
+        kind="extra",
+        github=False,
+        variable=True,
+        pyproject=str(tmp / "pyproject.toml"),
+        ci_file=str(tmp / ".github" / "workflows" / "ci.yml"),
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "inline workflow" in out and "defaults" in out
 
 
 def test_add_variable_skips_transport_and_superset(repo, capsys):
@@ -196,6 +217,33 @@ def test_add_variable_skips_transport_and_superset(repo, capsys):
     assert "COSMO_TEST_LEVEL" in pp.read_text()
     out = capsys.readouterr().out
     assert "vars context" in out
+
+
+def test_json_stub_pinned_to_old_tag_warns(capsys):
+    """Reviewer finding F2: a JSON stub pinned to a pre-JSON tag cannot start;
+    migrate_ci_to_stub must warn on any non-master pin with json transport."""
+    stub = migrate_ci_to_stub(pin="@0.2.14")
+    assert "uv-ci.yml@0.2.14" in stub
+    err = capsys.readouterr().err
+    assert "CANNOT START" in err and "--transport named" in err
+    # named transport with a pin is fine — no warning
+    migrate_ci_to_stub(pin="@0.2.14", transport="named")
+    assert "CANNOT START" not in capsys.readouterr().err
+
+
+def test_named_stub_warns_outside_superset_names(tmp_path, capsys):
+    """Named-mode generation warns per out-of-superset name (issue #63)."""
+    (tmp_path / "pyproject.toml").write_text(
+        PYPROJECT.replace("extra_envvars = []", 'extra_envvars = ["COSMO_TEST_LEVEL"]')
+    )
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    ci = wf / "ci.yml"
+    ci.write_text("name: x\n")
+    stub = migrate_ci_to_stub(str(ci), transport="named")
+    err = capsys.readouterr().err
+    assert "COSMO_TEST_LEVEL" in err and "startup_failure" in err
+    assert "COSMO_TEST_LEVEL: ${{ secrets.COSMO_TEST_LEVEL }}" in stub
 
 
 def test_repo_from_git_parses_urls(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #63.

## What

The caller stub now transports its **whole secrets context as one declared secret**:

```yaml
secrets:
  WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}
```

`on.workflow_call.secrets` must be static YAML — but *one* static name is enough. Any secret a repo has now reaches `uv-ci.yml`; which values become job env vars (and which are required) stays driven by `[tool.wads.ci.env]` in pyproject.toml. The 62-name superset stops being load-bearing: it stays declared, **frozen**, purely for already-deployed named-transport stubs.

This removes the whole `startup_failure` class from #63: there is no longer a fixed name list for a migrated repo to fall outside of.

## Why double-encoded, and re-masking

Two behaviors verified empirically on a live cross-owner probe (personal-account caller → this org's workflow):

- A multiline secret is masked **per line**; pretty-printed `toJSON(secrets)` would register its `{` / `}` lines as global masks and mangle every brace in the job log. `toJSON(toJSON(secrets))` is single-line, so only the whole blob is masked.
- Values extracted from the blob are **not** auto-masked, so `export-ci-env` now registers each secret-sourced value with `::add-mask::` (per line) before writing `$GITHUB_ENV`.

## Non-sensitive values (the other half of #63)

`COSMO_TEST_LEVEL`-style values shouldn't be secrets at all. Declared env vars now resolve **secrets-first, then the caller's repository variables** (the `vars` context resolves to the caller's repo inside a reusable workflow — verified live). So:

- committed constants → `[tool.wads.ci.env].defaults`
- per-repo non-sensitive values → `gh variable set NAME` (new: `wads-secrets add NAME --variable`)

## Changes

- `uv-ci.yml`: declares `WADS_CI_SECRETS_JSON` (+ frozen superset); export steps pass `toJSON(vars)`; publish job resolves `PYPI_PASSWORD` from either transport via a new `always-required` input and fails fast *before* the version bump.
- `actions/export-ci-env`: new `vars-json` / `always-required` inputs; installs wads from git when the action is referenced at a non-master ref (lets a wads branch be e2e-tested in lockstep before publishing).
- `wads/scripts/export_ci_env.py`: blob expansion (single- or double-encoded), secrets→vars resolution, add-mask emission, `ExportPlan` NamedTuple.
- `wads-migrate ci-to-stub --transport json|named` (json default). Named mode now **warns loudly** when a name is outside the frozen superset (the direct #63 ask), pointing at the three remedies.
- `wads-secrets`: JSON-stub aware (no stub edit needed, no superset warning); `--variable` for non-sensitive values.
- Stub template regenerated; characterization golden updated; 311 tests pass (the one deselected twine-check failure is pre-existing on master: local old-twine vs hatchling Metadata-Version 2.5).

## Verification (live, cross-owner)

A scratch personal-account repo called `uv-ci.yml@<this branch>` (with the export action temporarily pinned to the branch — commit + revert included):

- **JSON stub run: green.** Exported `PROBE_DEFAULT, WADS_PROBE_SECRET, COSMO_TEST_LEVEL, WADS_PROBE_VAR` — an out-of-superset secret via the blob, a repo-variable fallback, a committed default, and required-secret validation; masking confirmed.
- **Legacy named stub run against the same branch: green** (back-compat).

## Back-compat notes

- Old named stubs: unchanged behavior (superset still declared; export path identical when no blob is present).
- Repos pinned to an old `uv-ci.yml` tag: unaffected until they re-pin; a JSON stub requires a workflow ref that declares `WADS_CI_SECRETS_JSON` (i.e. master, or a tag from this change onward).
- Publish-lag window (minutes after this merges, before the new wads is on PyPI): old export code ignores the new inputs; named-stub publishing is unaffected because the token expression falls back to `secrets.PYPI_PASSWORD` directly.

## Security model

The JSON transport hands the called workflow every secret the caller has (the named transport only handed it the listed subset). For repos floating `@master` the trust boundary is unchanged in practice — the workflow author could already alter workflow behavior — but the widening is documented in the stub comments, README, and CLAUDE.md, and minimal-surface repos can keep named transport via `wads-migrate ci-to-stub --transport named`.

Research note: nothing in GitHub Actions (checked through Aug 2026, incl. the 2026 security roadmap's "scoped secrets") relaxes the static-interface constraint or makes `secrets: inherit` work cross-owner; the roadmap moves *toward* explicit secret binding, which this design aligns with.

https://claude.ai/code/session_01He11rkQPLPjxGNZTuR8kDY