### PR TITLE
Scope secret-backed env to the test jobs in the inline CI template

### DIFF
--- a/wads/ci_config.py
+++ b/wads/ci_config.py
@@ -20,6 +20,26 @@ else:
     except ImportError:
         raise ImportError("tomli package required for Python < 3.11")
 
+# Env keys the inline template's windows-validation job sets literally
+# (data/github_ci_uv.yml). The #TEST_ENV_VARS# substitution must not re-emit
+# them: a duplicate key in one YAML mapping fails the workflow at parse time.
+WINDOWS_JOB_LITERAL_ENV = ("PYTHONUTF8", "PYTHONIOENCODING")
+
+
+def render_minimal_env_placeholders(template_text: str, project_name: str) -> str:
+    """Render the inline template's env placeholders without a [tool.wads.ci]
+    config: workflow-level env gets PROJECT_NAME only, and the test-job
+    placeholders render empty (there are no declared secret-backed vars).
+
+    Used by the no-pyproject fallbacks in migration and populate so a shipped
+    workflow never carries literal placeholder lines.
+    """
+    return (
+        template_text.replace("#ENV_BLOCK#", f"  PROJECT_NAME: {project_name}")
+        .replace("#TEST_ENV_BLOCK#\n", "")
+        .replace("#TEST_ENV_VARS#\n", "")
+    )
+
 
 class CIConfig:
     """Represents CI configuration extracted from pyproject.toml."""
@@ -449,33 +469,44 @@ class CIConfig:
 
         return "\n".join(lines)
 
-    def generate_test_env_vars(self, *, indent: int = 6) -> str:
+    def generate_test_env_vars(self, *, indent: int = 6, exclude: tuple = ()) -> str:
         """
-        Generate job-level env entry lines for all secret-backed vars.
+        Generate job-level env entry lines for secret-backed vars.
 
         One `VAR: ${{ secrets.NAME || '' }}` line per name declared in
         required_envvars / test_envvars / extra_envvars, honoring
         [tool.wads.ci.env.secret_aliases] (env-var name -> backing secret
-        name). The `|| ''` keeps the workflow parseable when a secret is
-        unset. Returns '' when no secret-backed vars are declared.
+        name). An unset secret renders as an empty string. Returns '' when
+        nothing is left to emit.
+
+        Names also present in [tool.wads.ci.env].defaults are skipped: the
+        committed default is authoritative (matching the reusable workflow's
+        export-ci-env), and it already reaches every job from workflow level
+        — re-emitting `${{ secrets.X || '' }}` at job level would override
+        the default with '' in exactly the jobs that run tests.
 
         Args:
             indent: leading spaces per line (6 = entries of a job-level
                 `env:` block)
+            exclude: additional names to skip (e.g. keys the target job
+                already sets literally)
         """
         aliases = self.env_secret_aliases
+        skip = set(exclude) | set(self.env_vars_defaults)
         pad = " " * indent
         return "\n".join(
             f"{pad}{var_name}: ${{{{ secrets.{aliases.get(var_name, var_name)} || '' }}}}"
             for var_name in self.env_vars_all
+            if var_name not in skip
         )
 
     def generate_test_env_block(self) -> str:
         """
         Generate a whole job-level `env:` block for the validation job.
 
-        Returns '' when no secret-backed vars are declared, so the rendered
-        job simply has no `env:` key (an empty `env:` mapping is invalid).
+        Returns '' when no secret-backed vars are left to emit, so the
+        rendered job simply has no `env:` key (an empty `env:` mapping is
+        invalid).
         """
         entries = self.generate_test_env_vars()
         if not entries:
@@ -668,7 +699,12 @@ class CIConfig:
         return {
             "#ENV_BLOCK#": self.generate_env_block(),
             "#TEST_ENV_BLOCK#": self.generate_test_env_block(),
-            "#TEST_ENV_VARS#": self.generate_test_env_vars(),
+            # The windows-validation job sets these literally in the template;
+            # re-emitting a declared var of the same name would be a duplicate
+            # key in one mapping, which fails the whole workflow at parse time.
+            "#TEST_ENV_VARS#": self.generate_test_env_vars(
+                exclude=WINDOWS_JOB_LITERAL_ENV
+            ),
             "#ENV_VARS#": self.generate_env_vars_yaml(),
             "#SECRETS_BLOCK#": self.generate_stub_secrets_block(),
             "#PYTHON_VERSIONS#": json.dumps(self.python_versions),

--- a/wads/ci_config.py
+++ b/wads/ci_config.py
@@ -423,33 +423,64 @@ class CIConfig:
 
     def generate_env_block(self) -> str:
         """
-        Generate YAML env block for GitHub Actions.
+        Generate the workflow-level YAML env block for GitHub Actions.
 
-        Creates env vars for:
+        Contains ONLY non-secret values:
         - PROJECT_NAME (from config)
-        - Default env vars (from config.env.defaults)
-        - Placeholders for secret-based env vars (set via set-env-vars action)
+        - Literal defaults from [tool.wads.ci.env.defaults]
+
+        Secret-backed vars are deliberately NOT emitted at workflow level: a
+        workflow-level secret is in scope for the setup job too, and GitHub
+        refuses to emit any job OUTPUT containing a secret's value — a short
+        value (e.g. a test level of "3") silently blanks `python-versions`
+        and empties the test matrix (issue #61). Secret-backed vars are
+        scoped to the jobs that run tests via generate_test_env_block /
+        generate_test_env_vars.
 
         Returns:
-            YAML string for env section
+            YAML string for the workflow-level env section
         """
-        lines = []
+        lines = [f"  PROJECT_NAME: {self.project_name}"]
 
-        # Always include PROJECT_NAME
-        lines.append(f"  PROJECT_NAME: {self.project_name}")
-
-        # Add default environment variables (literal values, not secrets)
+        # Add default environment variables (literal values, not secrets —
+        # literals never become log masks, so workflow level is safe)
         for key, value in self.env_vars_defaults.items():
             lines.append(f"  {key}: {value}")
 
-        # Add env vars that come from secrets (using conditional syntax)
-        # These are set conditionally only if the secret exists
-        all_secret_vars = self.env_vars_all
-        for var_name in all_secret_vars:
-            # Use GitHub's conditional syntax to only set if secret exists
-            lines.append(f"  {var_name}: ${{{{ secrets.{var_name} || '' }}}}")
+        return "\n".join(lines)
 
-        return "\n".join(lines) if lines else ""
+    def generate_test_env_vars(self, *, indent: int = 6) -> str:
+        """
+        Generate job-level env entry lines for all secret-backed vars.
+
+        One `VAR: ${{ secrets.NAME || '' }}` line per name declared in
+        required_envvars / test_envvars / extra_envvars, honoring
+        [tool.wads.ci.env.secret_aliases] (env-var name -> backing secret
+        name). The `|| ''` keeps the workflow parseable when a secret is
+        unset. Returns '' when no secret-backed vars are declared.
+
+        Args:
+            indent: leading spaces per line (6 = entries of a job-level
+                `env:` block)
+        """
+        aliases = self.env_secret_aliases
+        pad = " " * indent
+        return "\n".join(
+            f"{pad}{var_name}: ${{{{ secrets.{aliases.get(var_name, var_name)} || '' }}}}"
+            for var_name in self.env_vars_all
+        )
+
+    def generate_test_env_block(self) -> str:
+        """
+        Generate a whole job-level `env:` block for the validation job.
+
+        Returns '' when no secret-backed vars are declared, so the rendered
+        job simply has no `env:` key (an empty `env:` mapping is invalid).
+        """
+        entries = self.generate_test_env_vars()
+        if not entries:
+            return ""
+        return "    env:\n" + entries
 
     def generate_env_vars_yaml(self) -> str:
         """
@@ -636,6 +667,8 @@ class CIConfig:
 
         return {
             "#ENV_BLOCK#": self.generate_env_block(),
+            "#TEST_ENV_BLOCK#": self.generate_test_env_block(),
+            "#TEST_ENV_VARS#": self.generate_test_env_vars(),
             "#ENV_VARS#": self.generate_env_vars_yaml(),
             "#SECRETS_BLOCK#": self.generate_stub_secrets_block(),
             "#PYTHON_VERSIONS#": json.dumps(self.python_versions),

--- a/wads/data/github_ci_uv.yml
+++ b/wads/data/github_ci_uv.yml
@@ -65,8 +65,13 @@ jobs:
     runs-on: ubuntu-latest
     # Secret-backed env vars from [tool.wads.ci.env] land here (test jobs
     # only, never workflow level — see the note on the top-level env block),
-    # rendered as `KEY: ${{ secrets.NAME || '' }}` so missing secrets don't
-    # fail parsing. The block is omitted entirely when none are declared.
+    # rendered as `KEY: ${{ secrets.NAME || '' }}` (an unset secret renders
+    # as an empty string). The block is omitted entirely when none are
+    # declared. Names also present in env.defaults are not re-emitted here:
+    # the committed default at workflow level stays authoritative (matching
+    # the reusable workflow's export-ci-env). The publish and github-pages
+    # jobs deliberately do not receive these vars either — parity with
+    # uv-ci.yml, where only the test jobs export them.
 #TEST_ENV_BLOCK#
     strategy:
       matrix:
@@ -142,7 +147,9 @@ jobs:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: "utf-8"
       # Secret-backed env vars from [tool.wads.ci.env] (see the note on the
-      # validation job). Empty when none are declared.
+      # validation job). Empty when none are declared. Names colliding with
+      # the literals above are skipped — a duplicate key in one mapping
+      # would fail the whole workflow at parse time.
 #TEST_ENV_VARS#
 
     steps:

--- a/wads/data/github_ci_uv.yml
+++ b/wads/data/github_ci_uv.yml
@@ -3,9 +3,14 @@ on: [push, pull_request]
 
 # Workflow-level env vars from [tool.wads.ci.env] in pyproject.toml.
 # Populated by wads-migrate / wads init via template substitution.
-# Includes PROJECT_NAME, literal defaults from env.defaults, and secret-
-# backed vars from required_envvars / test_envvars / extra_envvars,
-# rendered as `KEY: secrets.KEY || ''` so missing secrets don't fail parsing.
+# Contains ONLY non-secret values: PROJECT_NAME and literal defaults from
+# env.defaults. Secret-backed vars (required/test/extra_envvars) are
+# deliberately scoped to the jobs that run tests — see the validation and
+# windows-validation jobs below. A workflow-level secret would be in scope
+# for the setup job too, and GitHub then refuses to emit any job OUTPUT
+# containing its value: a short value (e.g. a test level of "3") silently
+# blanks python-versions, the matrix expands to nothing, and the run fails
+# with no failing step (i2mint/wads#61).
 env:
 #ENV_BLOCK#
 
@@ -58,6 +63,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     needs: setup
     runs-on: ubuntu-latest
+    # Secret-backed env vars from [tool.wads.ci.env] land here (test jobs
+    # only, never workflow level — see the note on the top-level env block),
+    # rendered as `KEY: ${{ secrets.NAME || '' }}` so missing secrets don't
+    # fail parsing. The block is omitted entirely when none are declared.
+#TEST_ENV_BLOCK#
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
@@ -131,6 +141,9 @@ jobs:
       # code reads source files or scripts print non-ASCII characters.
       PYTHONUTF8: "1"
       PYTHONIOENCODING: "utf-8"
+      # Secret-backed env vars from [tool.wads.ci.env] (see the note on the
+      # validation job). Empty when none are declared.
+#TEST_ENV_VARS#
 
     steps:
       - uses: actions/checkout@v6

--- a/wads/data/skills/wads-migrate/SKILL.md
+++ b/wads/data/skills/wads-migrate/SKILL.md
@@ -30,9 +30,9 @@ as an escape valve for repos that need to customize CI beyond `[tool.wads.ci.*]`
 | Con | Mitigation |
 |---|---|
 | Bad wads merge breaks CI everywhere on next run | Wads's own CI runs the reusable workflow first — canary catches obvious breaks. **Crucially: broken CI ≠ broken release.** Publish is gated on workflow success, so a bad wads change blocks publication for downstream consumers until wads is fixed, but never ships a broken artifact. This is what makes floating `@master` safe by default. |
-| Floating `@master` means consumers can't pin a known-good wads state | `wads-migrate ci-to-stub --pin @0.1.81` writes the stub with a tag pin instead of `@master` (i2mint tags are bare versions — **no `v` prefix**; `@v0.1.81` would reference a nonexistent ref). The pinned repo only picks up wads updates when explicitly re-pinned. Use for release-sensitive repos. |
-| A secret your tests need isn't reaching CI | Run `wads-secrets add VAR_NAME` (see "Secrets" below). It declares the var in `[tool.wads.ci.env]` AND adds the pass-through line to the stub. No workflow edit needed unless the name is outside the wads superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`), in which case the CLI warns and you either PR wads to widen the superset or use the inline escape valve. |
-| Secrets must reach a reusable workflow owned by a different account | The stub passes secrets **explicitly** (NOT `secrets: inherit`, which is unreliable cross-owner). The stub's `secrets:` block lists each name; it's generated from `[tool.wads.ci.env]` at migrate time and extended by `wads-secrets add`. |
+| Floating `@master` means consumers can't pin a known-good wads state | `wads-migrate ci-to-stub --pin @0.2.15` writes the stub with a tag pin instead of `@master` (i2mint tags are bare versions — **no `v` prefix**; `@v0.2.15` would reference a nonexistent ref). A default (JSON-transport) stub needs a tag from a release **after 0.2.14** — older tags don't declare `WADS_CI_SECRETS_JSON` and the workflow is rejected at parse time (the CLI warns loudly if you try). The pinned repo only picks up wads updates when explicitly re-pinned. Use for release-sensitive repos. |
+| A secret your tests need isn't reaching CI | Run `wads-secrets add VAR_NAME` (see "Secrets" below). It declares the var in `[tool.wads.ci.env]`; on the default JSON transport nothing else is needed (every repo secret is passed automatically). Only a stub on the opt-in *named* transport needs a pass-through line, which the CLI adds — refusing names outside the wads superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`), since passing one would make the workflow fail to start. |
+| Secrets must reach a reusable workflow owned by a different account | The stub passes secrets **explicitly** (NOT `secrets: inherit`, which is unreliable cross-owner). The default is the JSON transport — the whole `secrets` context serialized into the one declared secret `WADS_CI_SECRETS_JSON`. A named-transport stub instead lists each name, generated from `[tool.wads.ci.env]` at migrate time and extended by `wads-secrets add`. |
 
 ## Detecting Current Format
 
@@ -221,8 +221,9 @@ Storing such values as secrets has real costs: GitHub masks every occurrence
 of a secret's value in the logs of each job that receives it, so a short value
 garbles logs — and on inline workflows rendered before the issue-#61 fix, it
 can blank the config job's outputs and silently empty the test matrix.
-`wads-secrets add` warns when a secret value is short enough to be a mask
-hazard.
+When it has the value in hand (via `--value` or `$VAR_NAME`), `wads-secrets
+add` warns if it is short enough to be a mask hazard, with advice matched to
+the repo's CI shape.
 
 ## Secrets (two-layer model)
 
@@ -311,8 +312,9 @@ gh repo edit ORG/REPO --enable-discussions       # enable when false
 
 - [ ] `pyproject.toml` has correct metadata (name, version, dependencies)
 - [ ] `[tool.wads.ci]` section present (or defaults are acceptable)
-- [ ] Secrets the code needs are configured via `wads-secrets add` (declares in
-      `[tool.wads.ci.env]` AND passes them in the stub's `secrets:` block)
+- [ ] Secrets the code needs are configured via `wads-secrets add` (declares
+      in `[tool.wads.ci.env]`; on a named-transport stub it also adds the
+      pass-through line — the default JSON transport needs none)
 - [ ] `.github/workflows/ci.yml` is the stub (calls `uv-ci.yml@master`) OR the
       inline `github_ci_uv.yml` escape valve
 - [ ] `PYPI_PASSWORD` secret is a PyPI API token

--- a/wads/data/skills/wads-migrate/SKILL.md
+++ b/wads/data/skills/wads-migrate/SKILL.md
@@ -185,8 +185,12 @@ If a package's source modules read env vars at *import* time (e.g.
 pytest collection will fail during import.
 
 **For inline-CI repos**: add the var name to `[tool.wads.ci.env.test_envvars]`
-in pyproject.toml, then `wads-migrate ci-to-uv` to re-render the workflow with
-a top-level `env:` block wiring `${{ secrets.X || '' }}`. Set the GitHub secret.
+in pyproject.toml, then `wads-migrate ci-to-uv` to re-render the workflow —
+secret-backed vars are wired as `${{ secrets.X || '' }}` into the `env:` of the
+jobs that run tests, never at workflow level (a workflow-level secret is in
+scope for the config job, and GitHub then refuses to emit any job output
+containing its value — a short value silently blanks `python-versions` and
+empties the test matrix, issue #61). Set the GitHub secret.
 
 **For stub repos** (the default since wads 0.1.82): the simplest path is
 
@@ -200,24 +204,42 @@ This (a) declares the var in `[tool.wads.ci.env]` so the `export-ci-env` step
 writes it into the job environment, (b) adds the pass-through line to the stub's
 `secrets:` block so the secret is transported to the reusable workflow, and (c)
 `gh secret set`s the value if `gh` is installed (value from `$VAR_NAME` or
-`--value`). See the **Secrets** section below for the full model. If the secret
-name is outside the wads superset (`wads.ci_secrets.DEFAULT_CI_SECRETS`), the CLI
-warns; either PR wads to widen the superset (one line, ecosystem-wide) or use the
-inline `github_ci_uv.yml` escape valve.
+`--value`). See the **Secrets** section below for the full model. Superset
+limits only apply to stubs on the opt-in *named* transport (the CLI refuses an
+edit that would make such a stub fail to start); the default JSON transport
+accepts any secret name.
 
 Do NOT hand-edit job-level `env:` blocks in ci.yml. Declare via
 `[tool.wads.ci.env]` (or `wads-secrets add`, which is the safe way to do both).
+
+**Not actually sensitive?** A value that is just configuration — a test level,
+a flag, a region — belongs in a repository **variable**, not a secret:
+`wads-secrets add VAR_NAME --variable`. Declared env names fall back to the
+`vars` context automatically on stub repos (inline workflows have no vars
+fallback — use a committed literal in `[tool.wads.ci.env].defaults` there).
+Storing such values as secrets has real costs: GitHub masks every occurrence
+of a secret's value in the logs of each job that receives it, so a short value
+garbles logs — and on inline workflows rendered before the issue-#61 fix, it
+can blank the config job's outputs and silently empty the test matrix.
+`wads-secrets add` warns when a secret value is short enough to be a mask
+hazard.
 
 ## Secrets (two-layer model)
 
 Secrets reach a stub repo's CI through two coordinated layers:
 
-1. **Transport** — the stub's `secrets:` block *passes* named secrets to the
-   reusable workflow. Explicit pass-through is used (NOT `secrets: inherit`,
-   which is unreliable across GitHub accounts). The *universe* of passable
-   names is the superset declared in the wads-side `uv-ci.yml`
-   (`on.workflow_call.secrets`), generated from `wads.ci_secrets.DEFAULT_CI_SECRETS`.
-   Each repo's stub passes only `PYPI_PASSWORD` + the names it actually uses.
+1. **Transport** — the stub's `secrets:` block *passes* secrets to the
+   reusable workflow. The default (since the wads#64 fix) is the **JSON
+   transport**: the whole `secrets` context serialized into the one declared
+   secret `WADS_CI_SECRETS_JSON: ${{ toJSON(toJSON(secrets)) }}` — any secret
+   name works, there is no fixed list to fall outside of. The opt-in
+   alternative (`wads-migrate ci-to-stub --transport named`) passes each
+   secret by name for a minimal surface; named transport is limited to the
+   superset declared in the wads-side `uv-ci.yml` (`on.workflow_call.secrets`,
+   generated from `wads.ci_secrets.DEFAULT_CI_SECRETS`) — a stub naming
+   anything outside it fails at parse time (issue #63). Either way, explicit
+   pass-through is used, NOT `secrets: inherit` (unreliable across GitHub
+   accounts).
 2. **Env-assignment** — `[tool.wads.ci.env]` (`required_envvars`,
    `test_envvars`, `extra_envvars`, `defaults`, and `secret_aliases` for
    ENV_VAR≠SECRET_NAME) decides which passed secrets become job env vars. The
@@ -227,9 +249,11 @@ Secrets reach a stub repo's CI through two coordinated layers:
 
 **`wads-secrets add VAR_NAME [SECRET_NAME]`** does both layers (+ `gh secret set`)
 in one step — the recommended way. `wads-secrets list` shows what's configured;
-`wads-secrets superset` prints the allowed names. For a name outside the
-superset: PR `wads.ci_secrets.DEFAULT_CI_SECRETS` (benefits all repos) or use the
-inline `github_ci_uv.yml` escape valve.
+`wads-secrets superset` prints the names a *named*-transport stub may pass
+(irrelevant on the default JSON transport). For a named-transport repo needing
+a name outside the superset: regenerate with the JSON transport
+(`wads-migrate ci-to-stub`), PR `wads.ci_secrets.DEFAULT_CI_SECRETS` (benefits
+all repos), or use `--variable` if the value isn't sensitive.
 
 Publishing runs only on the repo's **default branch**, when validation passes,
 when the commit isn't `[skip ci]`, and when `[tool.wads.ci.publish].enabled`.

--- a/wads/migration.py
+++ b/wads/migration.py
@@ -788,6 +788,7 @@ def migrate_ci_to_uv(
     # When [tool.wads.ci] is absent, CIConfig still provides a sensible project_name
     # from [project], so the env: block always renders something valid.
     substitutions = None
+    ci_config = None
     if os.path.isfile(old_ci):
         repo_dir = os.path.dirname(os.path.abspath(old_ci))
         # Walk up to find pyproject.toml (typical layout: repo/.github/workflows/ci.yml)
@@ -797,9 +798,8 @@ def migrate_ci_to_uv(
                 try:
                     from wads.ci_config import CIConfig
 
-                    substitutions = CIConfig.from_file(
-                        candidate
-                    ).to_ci_template_substitutions()
+                    ci_config = CIConfig.from_file(candidate)
+                    substitutions = ci_config.to_ci_template_substitutions()
                 except Exception:
                     pass
                 break
@@ -812,20 +812,14 @@ def migrate_ci_to_uv(
             new_template = new_template.replace(placeholder, value)
     else:
         # No pyproject.toml found -> minimal default so yaml stays valid
+        from wads.ci_config import render_minimal_env_placeholders
+
         fallback_name = (
             defaults.get("project_name")
             or _extract_project_name_from_ci(old_content)
             or "PLACEHOLDER"
         )
-        new_template = new_template.replace(
-            "#ENV_BLOCK#", f"  PROJECT_NAME: {fallback_name}"
-        )
-        # Without a pyproject there are no declared secret-backed vars, so the
-        # test-job env placeholders render empty. (They are YAML comments in
-        # the raw template, but a shipped workflow shouldn't carry them.)
-        new_template = new_template.replace("#TEST_ENV_BLOCK#\n", "").replace(
-            "#TEST_ENV_VARS#\n", ""
-        )
+        new_template = render_minimal_env_placeholders(new_template, fallback_name)
 
     # Analyze old CI for migration warnings
     warnings = []
@@ -845,6 +839,14 @@ def migrate_ci_to_uv(
         warnings.append(
             "Old CI references setup.cfg - ensure project is migrated to "
             "pyproject.toml first (use: wads-migrate setup-to-pyproject)"
+        )
+    if ci_config is not None and ci_config.env_vars_all:
+        warnings.append(
+            "Secret-backed env vars are now scoped to the test jobs "
+            "(issue #61) - the publish and github-pages jobs no longer see "
+            "them (parity with the reusable workflow). If your docs build "
+            "imports modules that read these vars at import time, make the "
+            "reads tolerate absence or use [tool.wads.ci.env].defaults"
         )
 
     result = new_template

--- a/wads/migration.py
+++ b/wads/migration.py
@@ -820,6 +820,12 @@ def migrate_ci_to_uv(
         new_template = new_template.replace(
             "#ENV_BLOCK#", f"  PROJECT_NAME: {fallback_name}"
         )
+        # Without a pyproject there are no declared secret-backed vars, so the
+        # test-job env placeholders render empty. (They are YAML comments in
+        # the raw template, but a shipped workflow shouldn't carry them.)
+        new_template = new_template.replace("#TEST_ENV_BLOCK#\n", "").replace(
+            "#TEST_ENV_VARS#\n", ""
+        )
 
     # Analyze old CI for migration warnings
     warnings = []

--- a/wads/populate.py
+++ b/wads/populate.py
@@ -1079,6 +1079,13 @@ def _add_ci_def(
         else:
             # Basic substitutions for static template
             ci_def = ci_def.replace("#PROJECT_NAME#", name)
+            # If the inline uv template is being used without [tool.wads.ci],
+            # its env placeholders must still render (empty test-job blocks,
+            # PROJECT_NAME at workflow level) — a shipped workflow must not
+            # carry literal placeholder lines. No-op for other templates.
+            from wads.ci_config import render_minimal_env_placeholders
+
+            ci_def = render_minimal_env_placeholders(ci_def, name)
 
         # Legacy templates carried a #SECRETS_BLOCK# placeholder (per-repo
         # named transport). The current stub template passes the whole secrets

--- a/wads/secrets_cli.py
+++ b/wads/secrets_cli.py
@@ -55,6 +55,12 @@ _KINDS = {
 # not a mention of the name in a comment).
 _JSON_TRANSPORT_LINE_RE = re.compile(rf"(?m)^\s*{re.escape(JSON_TRANSPORT_SECRET)}\s*:")
 
+# Secret values shorter than this trigger a log-mask-hazard warning on
+# `wads-secrets add`: GitHub masks every occurrence of a secret's value in the
+# logs of any job that receives it, and a short value (a digit, a level) is
+# near-certain to collide with ordinary log text (issue #61).
+_MASK_HAZARD_VALUE_LEN = 8
+
 
 def _err(msg: str):
     print(f"error: {msg}", file=sys.stderr)
@@ -340,6 +346,17 @@ def _maybe_set_github_value(
             f"    gh {kind} set {secret_name} --repo {repo}"
         )
         return
+    if not variable and len(value) < _MASK_HAZARD_VALUE_LEN:
+        print(
+            f"⚠ value: {secret_name!r} is short ({len(value)} chars). GitHub "
+            f"registers every secret value as a log mask in any job that "
+            f"receives it, so a short value garbles logs (each occurrence "
+            f"becomes ***) — and on inline workflows rendered before the "
+            f"issue-#61 fix, it can blank the setup job's outputs and "
+            f"silently empty the test matrix. If this value is not sensitive "
+            f"(a level, a flag, a region), prefer a repository variable:\n"
+            f"    wads-secrets add {var_name} --variable"
+        )
     if set_github_secret(repo, secret_name, value, variable=variable):
         print(f"✓ github: set {kind} {secret_name!r} on {repo}")
 

--- a/wads/secrets_cli.py
+++ b/wads/secrets_cli.py
@@ -318,10 +318,49 @@ def add(
     return 0
 
 
+def _warn_if_mask_hazard(value, var_name, ci_file, *, variable=False):
+    """Warn when a short SECRET value is about to be configured (issue #61).
+
+    GitHub registers every secret value as a log mask in each job that
+    receives it, so a short value garbles logs — and on inline workflows
+    rendered before the issue-#61 template fix, it can blank the setup job's
+    outputs and silently empty the test matrix. The remedy differs by CI
+    shape: repo variables never reach an inline workflow's env, so there the
+    advice is a committed literal in [tool.wads.ci.env].defaults.
+    """
+    if variable or not value or len(value) >= _MASK_HAZARD_VALUE_LEN:
+        return
+    if stub_transport_mode(ci_file) == "inline":
+        remedy = (
+            f"put it in [tool.wads.ci.env].defaults as a committed literal "
+            f"(repo variables don't reach inline CI) and re-render with "
+            f"`wads-migrate ci-to-uv`"
+        )
+    else:
+        remedy = (
+            f"prefer a repository variable:\n"
+            f"    wads-secrets add {var_name} --variable"
+        )
+    print(
+        f"⚠ value: this is a short secret value ({len(value)} chars). GitHub "
+        f"registers every secret value as a log mask in any job that "
+        f"receives it, so a short value garbles logs (each occurrence "
+        f"becomes ***) — and on inline workflows rendered before the "
+        f"issue-#61 fix, it can blank the setup job's outputs and silently "
+        f"empty the test matrix. If this value is not sensitive (a level, a "
+        f"flag, a region), {remedy}"
+    )
+
+
 def _maybe_set_github_value(
     repo, secret_name, var_name, value, ci_file, *, variable=False
 ):
     kind = "variable" if variable else "secret"
+    if value is None:
+        value = os.environ.get(var_name) or os.environ.get(secret_name)
+    # Warn as soon as we hold a hazardous value — even when `gh` is absent
+    # and the user will run the `gh secret set` line by hand.
+    _warn_if_mask_hazard(value, var_name, ci_file, variable=variable)
     if not _gh_available():
         print(
             f"· github: `gh` not found; set it manually:\n"
@@ -337,8 +376,6 @@ def _maybe_set_github_value(
             f"    gh {kind} set {secret_name} --repo <org/repo>"
         )
         return
-    if value is None:
-        value = os.environ.get(var_name) or os.environ.get(secret_name)
     if not value:
         print(
             f"· github: no value for {secret_name!r} (pass --value or export "
@@ -346,17 +383,6 @@ def _maybe_set_github_value(
             f"    gh {kind} set {secret_name} --repo {repo}"
         )
         return
-    if not variable and len(value) < _MASK_HAZARD_VALUE_LEN:
-        print(
-            f"⚠ value: {secret_name!r} is short ({len(value)} chars). GitHub "
-            f"registers every secret value as a log mask in any job that "
-            f"receives it, so a short value garbles logs (each occurrence "
-            f"becomes ***) — and on inline workflows rendered before the "
-            f"issue-#61 fix, it can blank the setup job's outputs and "
-            f"silently empty the test matrix. If this value is not sensitive "
-            f"(a level, a flag, a region), prefer a repository variable:\n"
-            f"    wads-secrets add {var_name} --variable"
-        )
     if set_github_secret(repo, secret_name, value, variable=variable):
         print(f"✓ github: set {kind} {secret_name!r} on {repo}")
 

--- a/wads/tests/test_secrets_cli.py
+++ b/wads/tests/test_secrets_cli.py
@@ -261,3 +261,42 @@ def test_repo_from_git_parses_urls(tmp_path, monkeypatch):
         lambda *a, **k: "https://github.com/org/repo\n",
     )
     assert m._repo_from_git(".") == "org/repo"
+
+
+def test_short_secret_value_warns_mask_hazard(monkeypatch, capsys):
+    """Issue #61 suggested fix (2): a short secret value is a log-mask
+    hazard — warn and point at --variable, but still set the value (it's a
+    warning, not a refusal)."""
+    import wads.secrets_cli as m
+
+    monkeypatch.setattr(m, "_gh_available", lambda: True)
+    set_calls = []
+    monkeypatch.setattr(
+        m,
+        "set_github_secret",
+        lambda *a, **k: set_calls.append((a, k)) or True,
+    )
+
+    m._maybe_set_github_value(
+        "org/demo", "COSMO_TEST_LEVEL", "COSMO_TEST_LEVEL", "3", "ci.yml"
+    )
+    out = capsys.readouterr().out
+    assert "mask" in out and "--variable" in out
+    assert len(set_calls) == 1
+
+    # A value of typical credential length does not warn
+    m._maybe_set_github_value(
+        "org/demo", "API_KEY", "API_KEY", "sk-0123456789abcdef", "ci.yml"
+    )
+    assert "mask" not in capsys.readouterr().out
+
+    # Repository variables are never masked, so no warning there
+    m._maybe_set_github_value(
+        "org/demo",
+        "COSMO_TEST_LEVEL",
+        "COSMO_TEST_LEVEL",
+        "3",
+        "ci.yml",
+        variable=True,
+    )
+    assert "mask" not in capsys.readouterr().out

--- a/wads/tests/test_secrets_cli.py
+++ b/wads/tests/test_secrets_cli.py
@@ -300,3 +300,42 @@ def test_short_secret_value_warns_mask_hazard(monkeypatch, capsys):
         variable=True,
     )
     assert "mask" not in capsys.readouterr().out
+
+
+def test_mask_hazard_warning_fires_without_gh(monkeypatch, capsys):
+    """The hazard must be flagged whenever wads holds the value — including
+    when `gh` is absent and the user will run `gh secret set` by hand
+    (adversarial-review finding: the old order returned before the check)."""
+    import wads.secrets_cli as m
+
+    monkeypatch.setattr(m, "_gh_available", lambda: False)
+    m._maybe_set_github_value(
+        "org/demo", "COSMO_TEST_LEVEL", "COSMO_TEST_LEVEL", "3", "ci.yml"
+    )
+    out = capsys.readouterr().out
+    assert "mask" in out
+    assert "gh secret set" in out  # manual instruction still printed
+
+
+def test_mask_hazard_advice_matches_ci_shape(tmp_path, monkeypatch, capsys):
+    """--variable is a dead end on inline repos (no vars fallback), so the
+    remedy there must be a committed default, not --variable."""
+    import wads.secrets_cli as m
+
+    monkeypatch.setattr(m, "_gh_available", lambda: True)
+    monkeypatch.setattr(m, "set_github_secret", lambda *a, **k: True)
+
+    inline_ci = tmp_path / "ci.yml"
+    inline_ci.write_text("name: CI\non: [push]\njobs: {}\n")
+    m._maybe_set_github_value(
+        "org/demo", "COSMO_TEST_LEVEL", "COSMO_TEST_LEVEL", "3", str(inline_ci)
+    )
+    out = capsys.readouterr().out
+    assert "defaults" in out and "--variable" not in out
+
+    stub_ci = tmp_path / "stub.yml"
+    stub_ci.write_text(migrate_ci_to_stub())
+    m._maybe_set_github_value(
+        "org/demo", "COSMO_TEST_LEVEL", "COSMO_TEST_LEVEL", "3", str(stub_ci)
+    )
+    assert "--variable" in capsys.readouterr().out

--- a/wads/tests/test_uv_workflow_template.py
+++ b/wads/tests/test_uv_workflow_template.py
@@ -375,5 +375,102 @@ class TestCIConfigTesting:
         assert CIConfig(data).tests_enabled is False
 
 
+class TestSecretEnvScoping:
+    """Issue #61: secret-backed env vars must never be in scope for the setup
+    job. A workflow-level secret gets registered as a log mask for every job,
+    and GitHub then refuses to emit any job OUTPUT containing its value — a
+    short value (e.g. a test level of "3") silently blanks python-versions
+    and the test matrix expands to nothing."""
+
+    SECRET_CI = {
+        "project": {"name": "demo"},
+        "tool": {
+            "wads": {
+                "ci": {
+                    "env": {
+                        "required_envvars": [],
+                        "test_envvars": ["OPENAI_API_KEY", "HF_TOKEN"],
+                        "extra_envvars": ["COSMO_TEST_LEVEL"],
+                        "defaults": {"PYTHONUNBUFFERED": "1"},
+                        "secret_aliases": {"HF_TOKEN": "HF_WRITE_TOKEN"},
+                    },
+                }
+            }
+        },
+    }
+
+    @pytest.fixture
+    def template_content(self):
+        """Load the inline uv template's raw content."""
+        from wads import data_dir
+
+        return (Path(data_dir) / "github_ci_uv.yml").read_text()
+
+    def _render(self, template_content, pyproject_data):
+        from wads.ci_config import CIConfig
+
+        rendered = template_content
+        substitutions = CIConfig(pyproject_data).to_ci_template_substitutions()
+        for placeholder, value in substitutions.items():
+            rendered = rendered.replace(placeholder, value)
+        return rendered
+
+    def test_workflow_level_env_has_no_secrets(self, template_content):
+        """Workflow-level env carries only PROJECT_NAME + literal defaults."""
+        data = yaml.safe_load(self._render(template_content, self.SECRET_CI))
+        workflow_env = data["env"]
+        assert workflow_env["PROJECT_NAME"] == "demo"
+        assert str(workflow_env["PYTHONUNBUFFERED"]) == "1"
+        assert "secrets." not in str(workflow_env)
+
+    def test_setup_job_sees_no_secrets(self, template_content):
+        """The job that emits python-versions must reference no secret."""
+        import json
+
+        data = yaml.safe_load(self._render(template_content, self.SECRET_CI))
+        setup_job = data["jobs"]["setup"]
+        assert "env" not in setup_job
+        assert "secrets." not in json.dumps(setup_job)
+
+    def test_validation_job_gets_secret_env(self, template_content):
+        """Secret-backed vars land in the validation job's env, aliased
+        names reading their backing secret."""
+        data = yaml.safe_load(self._render(template_content, self.SECRET_CI))
+        env = data["jobs"]["validation"]["env"]
+        assert env["OPENAI_API_KEY"] == "${{ secrets.OPENAI_API_KEY || '' }}"
+        assert env["COSMO_TEST_LEVEL"] == "${{ secrets.COSMO_TEST_LEVEL || '' }}"
+        assert env["HF_TOKEN"] == "${{ secrets.HF_WRITE_TOKEN || '' }}"
+
+    def test_windows_job_gets_secret_env_and_keeps_utf8(self, template_content):
+        """The windows job's existing UTF-8 env entries survive the merge."""
+        data = yaml.safe_load(self._render(template_content, self.SECRET_CI))
+        env = data["jobs"]["windows-validation"]["env"]
+        assert str(env["PYTHONUTF8"]) == "1"
+        assert env["COSMO_TEST_LEVEL"] == "${{ secrets.COSMO_TEST_LEVEL || '' }}"
+
+    def test_no_secret_vars_renders_valid_yaml_without_env(self, template_content):
+        """With nothing declared, the validation job has no env key at all
+        (an empty env: mapping would be invalid), and no placeholder leaks."""
+        rendered = self._render(template_content, {"project": {"name": "demo"}})
+        for placeholder in ("#ENV_BLOCK#", "#TEST_ENV_BLOCK#", "#TEST_ENV_VARS#"):
+            assert placeholder not in rendered
+        data = yaml.safe_load(rendered)
+        assert "env" not in data["jobs"]["validation"]
+        # windows keeps its literal UTF-8 entries even with no secret vars
+        assert str(data["jobs"]["windows-validation"]["env"]["PYTHONUTF8"]) == "1"
+
+    def test_fallback_render_strips_placeholders(self):
+        """migrate_ci_to_uv without a pyproject.toml (string input) must not
+        leak placeholders and must stay valid YAML."""
+        from wads.migration import migrate_ci_to_uv
+
+        result = migrate_ci_to_uv("name: CI\non: push")
+        assert "#ENV_BLOCK#" not in result
+        assert "#TEST_ENV" not in result
+        data = yaml.safe_load(result)
+        assert "env" not in data["jobs"]["validation"]
+        assert "secrets." not in str(data.get("env", {}))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/wads/tests/test_uv_workflow_template.py
+++ b/wads/tests/test_uv_workflow_template.py
@@ -459,6 +459,81 @@ class TestSecretEnvScoping:
         # windows keeps its literal UTF-8 entries even with no secret vars
         assert str(data["jobs"]["windows-validation"]["env"]["PYTHONUTF8"]) == "1"
 
+    def test_default_is_authoritative_over_same_named_secret(self, template_content):
+        """A var in BOTH env.defaults and an envvars bucket renders only at
+        workflow level (the committed default), never as a job-level
+        `${{ secrets.X || '' }}` that would override it with '' in the test
+        jobs (adversarial-review finding; matches export-ci-env semantics)."""
+        config = {
+            "project": {"name": "demo"},
+            "tool": {
+                "wads": {
+                    "ci": {
+                        "env": {
+                            "extra_envvars": ["COSMO_TEST_LEVEL"],
+                            "defaults": {"COSMO_TEST_LEVEL": "3"},
+                        }
+                    }
+                }
+            },
+        }
+        data = yaml.safe_load(self._render(template_content, config))
+        assert str(data["env"]["COSMO_TEST_LEVEL"]) == "3"
+        # the only declared var is defaulted, so the test jobs add nothing
+        assert "env" not in data["jobs"]["validation"]
+        assert "COSMO_TEST_LEVEL" not in data["jobs"]["windows-validation"]["env"]
+
+    def test_windows_literal_env_keys_are_not_duplicated(self, template_content):
+        """Declaring PYTHONUTF8 as an envvar must not render a duplicate key
+        in the windows job's env mapping (which fails the whole workflow at
+        parse time); the validation job still receives it."""
+        config = {
+            "project": {"name": "demo"},
+            "tool": {"wads": {"ci": {"env": {"test_envvars": ["PYTHONUTF8"]}}}},
+        }
+        rendered = self._render(template_content, config)
+        data = yaml.safe_load(rendered)
+        assert (
+            data["jobs"]["validation"]["env"]["PYTHONUTF8"]
+            == "${{ secrets.PYTHONUTF8 || '' }}"
+        )
+        assert str(data["jobs"]["windows-validation"]["env"]["PYTHONUTF8"]) == "1"
+        # exactly one PYTHONUTF8 key line inside the windows job's env
+        windows_section = rendered[rendered.index("windows-validation:") :]
+        windows_section = windows_section[: windows_section.index("steps:")]
+        assert windows_section.count("PYTHONUTF8:") == 1
+
+    def test_migrate_warns_about_test_job_scoping(self, tmp_path):
+        """migrate_ci_to_uv announces the #61 scoping change when the repo
+        declares secret-backed vars, and stays quiet when it declares none."""
+        from wads.migration import migrate_ci_to_uv
+
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        (wf / "ci.yml").write_text("name: old\non: push\n")
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\n\n'
+            "[tool.wads.ci.env]\nextra_envvars = [\"COSMO_TEST_LEVEL\"]\n"
+        )
+        result = migrate_ci_to_uv(wf / "ci.yml")
+        assert "scoped to the test jobs" in result
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+        result = migrate_ci_to_uv(wf / "ci.yml")
+        assert "scoped to the test jobs" not in result
+
+    def test_minimal_placeholder_render_helper(self, template_content):
+        """render_minimal_env_placeholders (used by the populate static path
+        and the migrate fallback) leaks no placeholders and stays valid."""
+        from wads.ci_config import render_minimal_env_placeholders
+
+        rendered = render_minimal_env_placeholders(template_content, "demo")
+        for placeholder in ("#ENV_BLOCK#", "#TEST_ENV_BLOCK#", "#TEST_ENV_VARS#"):
+            assert placeholder not in rendered
+        data = yaml.safe_load(rendered)
+        assert data["env"]["PROJECT_NAME"] == "demo"
+        assert "env" not in data["jobs"]["validation"]
+
     def test_fallback_render_strips_placeholders(self):
         """migrate_ci_to_uv without a pyproject.toml (string input) must not
         leak placeholders and must stay valid YAML."""


### PR DESCRIPTION
Closes #61.

## The bug

Both CI shapes used to render secret-backed vars from `[tool.wads.ci.env]` into a **workflow-level** `env:` block. That puts every such secret in scope for the "Read Configuration" job, so GitHub registers its value as a log mask there and refuses to emit any job output containing it — a short value (e.g. a `COSMO_TEST_LEVEL` of `3`) silently blanks `python-versions`, the matrix expands to nothing, and the run fails with no failing step. The reusable workflow was fixed as part of #64 (secrets enter env only via `export-ci-env`, never in setup); this PR brings the inline template `github_ci_uv.yml` to the same structure, plus #61's suggested fixes (2) and (3).

## What changed

- **Template**: workflow-level `env:` now carries only `PROJECT_NAME` + literal `defaults`; secret-backed vars render into the validation job's env (`#TEST_ENV_BLOCK#`) and merge into windows-validation's existing env (`#TEST_ENV_VARS#`). Publish and github-pages deliberately do not receive them — parity with `uv-ci.yml` — and `migrate_ci_to_uv` announces that scoping in a MIGRATION NOTE whenever the repo declares secret-backed vars.
- **Rendering** (`ci_config.py`): new `generate_test_env_vars` / `generate_test_env_block`, which honor `secret_aliases` (the old workflow-level rendering read the wrong secret name for aliased vars) and skip names present in `env.defaults` — the committed default is authoritative (matching `export-ci-env`); re-emitting `${{ secrets.X || '' }}` at job level would override it with `''` in exactly the test jobs. The windows job's literal `PYTHONUTF8`/`PYTHONIOENCODING` keys are excluded to avoid duplicate-key parse failures.
- **Fallbacks**: shared `render_minimal_env_placeholders` so neither the migrate no-pyproject path nor populate's static-template path ships literal placeholder lines.
- **CLI** (#61 fix 2): `wads-secrets add` warns when the value it holds is short enough to be a mask hazard — before the `gh`-availability checks, with advice matched to CI shape (`--variable` on stubs; a committed default on inline repos, where repo variables never arrive).
- **Docs** (#61 fix 3): the wads-migrate skill now documents the secrets-vs-repository-variables rule, and its Cons table / checklist / Secrets section were corrected to the post-#64 JSON-transport reality (they still taught the named-transport superset model as current).

## Review

Pre-landing adversarial review: 4 lenses (Actions semantics, rendering code, fleet/consumer impact, doc truthfulness), 19 raw findings, 12 confirmed after per-finding adversarial verification — all 12 addressed in the follow-up commits, each with a regression test where testable. Notable catches: the defaults/envvars split-brain (old rendering failed loudly on that config; the naive fix made it silently wrong), the windows duplicate-key parse failure, and the unreachable-warning doc overpromise.

Existing repos on rendered inline workflows are untouched until they re-run `wads-migrate ci-to-uv`; the MIGRATION NOTE covers them when they do.

https://claude.ai/code/session_0178p18Djy8uQDSERAYzfcMw
